### PR TITLE
fix: Return to custom version handling as pbr does not work with semantic bot

### DIFF
--- a/hip_data_tools/common.py
+++ b/hip_data_tools/common.py
@@ -24,7 +24,7 @@ def get_release_version():
 
 def get_long_description():
     """
-    Get the contents of reame file as long_description
+    Get the contents of readme file as long_description
     Returns: bytes containing readme file
 
     """

--- a/hip_data_tools/common.py
+++ b/hip_data_tools/common.py
@@ -3,8 +3,31 @@ Module contains variables and methods used for common / shared operations throug
 """
 
 import logging
+import os
 
 LOG = logging.getLogger(__name__)
 """
 logger object to handle logging in the entire package
 """
+
+
+def get_release_version():
+    """
+    Gets the Release version based on the latest git tag from GIT_TAG env var, else returns 0.0
+    Returns: string containing version for the release
+
+    """
+    git_version = os.getenv("GIT_TAG", "v0.0")
+    pypi_version = git_version.lstrip("v").strip()
+    return pypi_version
+
+
+def get_long_description():
+    """
+    Get the contents of reame file as long_description
+    Returns: bytes containing readme file
+
+    """
+    file_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'README.md'))
+    with open(file_path) as readme_file:
+        return readme_file.read()

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,10 @@
 """
 Setup and release this package for wider consumption using setup tools
 """
-import os
 
 from setuptools import setup, find_packages
 
-
-def get_long_description():
-    """
-    Get the contents of reame file as long_description
-    Returns: bytes containing readme file
-
-    """
-    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'README.md'),
-              encoding='utf8') as readme_file:
-        return readme_file.read()
-
+from hip_data_tools.common import get_release_version, get_long_description
 
 setup(
     long_description=get_long_description(),
@@ -29,5 +18,5 @@ setup(
     tests_require=[
     ],
     python_requires='~=3.6',
-    pbr=True
+    version=get_release_version(),
 )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,7 +8,7 @@ class TestCommon(TestCase):
     def test__get_release_version__parses_tag(self):
         os.environ["GIT_TAG"] = "v1.3"
         actual = get_release_version()
-        expected = "0.0"
+        expected = "1.3"
         self.assertEquals(actual, expected)
 
     def test__get_release_version__works_without_tag(self):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,23 @@
+import os
+from unittest import TestCase
+
+from hip_data_tools.common import get_release_version, get_long_description
+
+
+class TestCommon(TestCase):
+    def test__get_release_version__parses_tag(self):
+        os.environ["GIT_TAG"] = "v0.0"
+        actual = get_release_version()
+        expected = "0.0"
+        self.assertEquals(actual, expected)
+
+    def test__get_release_version__works_without_tag(self):
+        del os.environ["GIT_TAG"]
+        actual = get_release_version()
+        expected = "0.0"
+        self.assertEquals(actual, expected)
+
+    def test__get_long_description__reads_readme(self):
+        actual = get_long_description()[0:16]
+        expected = "# hip-data-tools"
+        self.assertEquals(actual, expected)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,7 +6,7 @@ from hip_data_tools.common import get_release_version, get_long_description
 
 class TestCommon(TestCase):
     def test__get_release_version__parses_tag(self):
-        os.environ["GIT_TAG"] = "v0.0"
+        os.environ["GIT_TAG"] = "v1.3"
         actual = get_release_version()
         expected = "0.0"
         self.assertEquals(actual, expected)


### PR DESCRIPTION
### Link to Github Issue
---
* #5

### What changes are proposed in this PR?
---
* Revert back to using custom version picked from semantic bot
* stop using pbr

### How was this tested?
---
* see unit tests

