### PR TITLE
feat: Add dataframe methods to s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,10 @@ jobs:
           command: |
             sudo pip3 install --upgrade setuptools coverage
       - run:
+          name: install snappy as its used in tests
+          command: |
+            sudo apt-get install libsnappy-dev
+      - run:
           name: run tests using setuptools
           command: |
             ./cc-test-reporter before-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
           name: run tests using setuptools
           command: |
             ./cc-test-reporter before-build
-            coverage run setup.py test
+            coverage run --source hip_data_tools setup.py test
             coverage xml
             ./cc-test-reporter after-build -t coverage.py
             coverage report

--- a/hip_data_tools/aws/s3.py
+++ b/hip_data_tools/aws/s3.py
@@ -1,7 +1,7 @@
 """
 Utility to connect to, and interact with the s3 file storage system
 """
-
+import pandas as pd
 import uuid
 
 from joblib import load, dump
@@ -57,18 +57,22 @@ class S3Util:
         self.download_file(s3_key=s3_key, local_file_path=local_file_path)
         return load(local_file_path)
 
-    def serialise_and_upload_object(self, obj, path_on_s3):
+    def serialise_and_upload_object(self, obj, s3_key):
         """
         Serialise any object to disk, and then upload to S3
         Args:
             obj (object): Any serialisable object
-            path_on_s3 (string): The absolute path on s3 to upload the file to
+            s3_key (string): The absolute path on s3 to upload the file to
         Returns: None
         """
 
-        random_tmp_file_nm = "/tmp/tmp_file" + str(uuid.uuid4())
+        random_tmp_file_nm = self._generate_random_file_name()
         dump(obj, random_tmp_file_nm)
-        self.upload_file(local_file_path=random_tmp_file_nm, s3_key=path_on_s3)
+        self.upload_file(local_file_path=random_tmp_file_nm, s3_key=s3_key)
+
+    def _generate_random_file_name(self):
+        random_tmp_file_nm = "/tmp/tmp_file" + str(uuid.uuid4())
+        return random_tmp_file_nm
 
     def create_bucket(self):
         """
@@ -76,3 +80,26 @@ class S3Util:
         Returns: None
         """
         self.conn.resource(self.boto_type).create_bucket(Bucket=self.bucket)
+
+    def upload_df_parquet(self, df, s3_key):
+        """
+        Exports a datafame to a parquet file on s3
+        Args:
+            df (DataFrame): dataframe to export
+            s3_key (str): The absolute path on s3 to upload the file to
+        Returns: None
+        """
+        random_tmp_file_nm = self._generate_random_file_name()
+        df.to_parquet(random_tmp_file_nm)
+        self.upload_file(random_tmp_file_nm, s3_key)
+
+    def download_df_parquet(self, s3_key, engine='auto', columns=None, **kwargs):
+        """
+        Exports a datafame to a parquet file on s3
+        Args:
+            s3_key (str): The absolute path on s3 to upload the file to
+        Returns: DataFrame
+        """
+        random_tmp_file_nm = self._generate_random_file_name()
+        self.download_file(random_tmp_file_nm, s3_key)
+        return pd.read_parquet(random_tmp_file_nm, engine=engine, columns=columns, **kwargs)

--- a/hip_data_tools/aws/s3.py
+++ b/hip_data_tools/aws/s3.py
@@ -6,7 +6,7 @@ import uuid
 import pandas as pd
 from joblib import load, dump
 
-from common import _generate_random_file_name
+from hip_data_tools.common import _generate_random_file_name
 
 
 class S3Util:

--- a/hip_data_tools/aws/s3.py
+++ b/hip_data_tools/aws/s3.py
@@ -1,10 +1,12 @@
 """
 Utility to connect to, and interact with the s3 file storage system
 """
-import pandas as pd
 import uuid
 
+import pandas as pd
 from joblib import load, dump
+
+from common import _generate_random_file_name
 
 
 class S3Util:
@@ -66,13 +68,9 @@ class S3Util:
         Returns: None
         """
 
-        random_tmp_file_nm = self._generate_random_file_name()
+        random_tmp_file_nm = _generate_random_file_name()
         dump(obj, random_tmp_file_nm)
         self.upload_file(local_file_path=random_tmp_file_nm, s3_key=s3_key)
-
-    def _generate_random_file_name(self):
-        random_tmp_file_nm = "/tmp/tmp_file{}".format(str(uuid.uuid4()))
-        return random_tmp_file_nm
 
     def create_bucket(self):
         """
@@ -89,7 +87,7 @@ class S3Util:
             s3_key (str): The absolute path on s3 to upload the file to
         Returns: None
         """
-        random_tmp_file_nm = self._generate_random_file_name()
+        random_tmp_file_nm = _generate_random_file_name()
         df.to_parquet(random_tmp_file_nm)
         self.upload_file(random_tmp_file_nm, s3_key)
 
@@ -100,6 +98,6 @@ class S3Util:
             s3_key (str): The absolute path on s3 to upload the file to
         Returns: DataFrame
         """
-        random_tmp_file_nm = self._generate_random_file_name()
+        random_tmp_file_nm = _generate_random_file_name()
         self.download_file(random_tmp_file_nm, s3_key)
         return pd.read_parquet(random_tmp_file_nm, engine=engine, columns=columns, **kwargs)

--- a/hip_data_tools/common.py
+++ b/hip_data_tools/common.py
@@ -4,6 +4,7 @@ Module contains variables and methods used for common / shared operations throug
 
 import logging
 import os
+import uuid
 
 LOG = logging.getLogger(__name__)
 """
@@ -31,3 +32,8 @@ def get_long_description():
     file_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'README.md'))
     with open(file_path) as readme_file:
         return readme_file.read()
+
+
+def _generate_random_file_name():
+    random_tmp_file_nm = "/tmp/tmp_file{}".format(str(uuid.uuid4()))
+    return random_tmp_file_nm

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,13 @@ setup(
     install_requires=[
         "boto3==1.9.216",
         "joblib==0.13.2",
+        "pandas==0.25.1",
     ],
     test_suite="tests",
     tests_require=[
         "moto==1.3.13",
+        "pyarrow==0.14.1",
+        "python-snappy==0.5.4",
     ],
     python_requires='~=3.6',
     version=get_release_version(),

--- a/tests/aws/test_athena.py
+++ b/tests/aws/test_athena.py
@@ -54,7 +54,7 @@ class TestAthenaUtil(TestCase):
         """
         print(actual)
         self.maxDiff = None
-        self.assertEquals(actual.split(), expected.split())
+        self.assertEqual(actual.split(), expected.split())
 
     def test__build_create_table_for_csv_data(self):
         actual = self.au._build_create_table_sql(
@@ -100,7 +100,7 @@ class TestAthenaUtil(TestCase):
         """
         print(actual)
         self.maxDiff = None
-        self.assertEquals(actual.split(), expected.split())
+        self.assertEqual(actual.split(), expected.split())
 
     def test__generate_parquet_ctas__creates_correct_syntax(self):
         actual = athena.generate_parquet_ctas(
@@ -116,7 +116,7 @@ class TestAthenaUtil(TestCase):
         ) AS
         SELECT abc FROM def
         """
-        self.assertEquals(actual.split(), expected.split())
+        self.assertEqual(actual.split(), expected.split())
 
     def test__generate_csv_ctas__creates_correct_syntax(self):
         actual = athena.generate_csv_ctas(
@@ -133,7 +133,7 @@ class TestAthenaUtil(TestCase):
         ) AS
         SELECT abc FROM def
         """
-        self.assertEquals(actual.split(), expected.split())
+        self.assertEqual(actual.split(), expected.split())
 
     def test__zip_columns__works_with_one(self):
         input = [{
@@ -142,7 +142,7 @@ class TestAthenaUtil(TestCase):
         }]
         actual = athena.zip_columns(input)
         expected = "abc def"
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test__zip_columns__works_with_two(self):
         input = [{
@@ -154,13 +154,13 @@ class TestAthenaUtil(TestCase):
         }]
         actual = athena.zip_columns(input)
         expected = "abc def, pqr stu"
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test__zip_columns__works_with_none(self):
         input = []
         actual = athena.zip_columns(input)
         expected = ""
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_drop_table__works_as_intended(self):
         with self.assertRaises(AttributeError):

--- a/tests/aws/test_s3.py
+++ b/tests/aws/test_s3.py
@@ -2,7 +2,9 @@ import os
 import uuid
 from unittest import TestCase
 
+import pandas as pd
 from moto import mock_s3
+from pandas.util.testing import assert_frame_equal
 
 from hip_data_tools.authenticate import AwsConnection
 from hip_data_tools.aws.s3 import S3Util
@@ -43,6 +45,18 @@ class TestS3Util(TestCase):
         s3u.create_bucket()
         upload_key = "temp.pickle"
         test_object = {"this": "is good"}
-        s3u.serialise_and_upload_object(obj=test_object, path_on_s3=upload_key)
+        s3u.serialise_and_upload_object(obj=test_object, s3_key=upload_key)
         actual_object = s3u.download_object_and_deserialse(s3_key=upload_key)
         self.assertEqual(test_object, actual_object)
+
+    @mock_s3
+    def test_should__upload_dataframe_and_download_parquet__when_using_s3util(self):
+        bucket = "TEST_BUCKET3"
+        conn = AwsConnection(mode="standard_env_var", region_name="ap-southeast-2", settings={})
+        s3u = S3Util(conn=conn, bucket=bucket)
+        s3u.create_bucket()
+        upload_key = "temp.pickle"
+        test_object = pd.DataFrame([1, 2, 3, 4], columns=["one"])
+        s3u.upload_df_parquet(df=test_object, s3_key=upload_key)
+        redown_df = s3u.download_df_parquet(upload_key)
+        assert_frame_equal(test_object, redown_df)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -9,15 +9,15 @@ class TestCommon(TestCase):
         os.environ["GIT_TAG"] = "v1.3"
         actual = get_release_version()
         expected = "1.3"
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test__get_release_version__works_without_tag(self):
         del os.environ["GIT_TAG"]
         actual = get_release_version()
         expected = "0.0"
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test__get_long_description__reads_readme(self):
         actual = get_long_description()[0:16]
         expected = "# hip-data-tools"
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
### Link to Github Issue
---
* https://github.com/hipagesgroup/data-tools/issues/14

### What changes are proposed in this PR?
---
* Added 2 new methods to s3 utility to upload and dlownload pandas data frames in form of parquet files
* Circle ci changes to make the tests work as seen in - https://github.com/hipagesgroup/repo-man/pull/81

### How was this tested?
---
* Unit tests with mocked s3

