### PR TITLE
feat: [DP-285] Add support for transfer of entire Athena tables to Cassandra

### DIFF
--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -293,7 +293,7 @@ class CassandraUtil:
         log.debug(upsert_sql)
         return upsert_sql
 
-    def upsert_dataframe(self, dataframe: DataFrame, table: str, batch_size: int=2) -> list:
+    def upsert_dataframe(self, dataframe: DataFrame, table: str, batch_size: int = 2) -> list:
         """
         Upload all data from a DataFrame onto a cassandra table
         Args:
@@ -328,7 +328,7 @@ class CassandraUtil:
         log.debug("Executing query: %s", batch)
         return self._session.execute(batch, timeout=300.0)
 
-    def upsert_dict(self, data: list, table: str, batch_size: int=2) -> list:
+    def upsert_dict(self, data: list, table: str, batch_size: int = 2) -> list:
         """
         Upsert a row into the cassandra table based on the dictionary key values
         Args:

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -284,7 +284,7 @@ class CassandraUtil:
         ({", ".join(data[0])}) 
         VALUES ({", ".join(['?' for key in data[0]])});
             """
-        log.info(upsert_sql)
+        log.debug(upsert_sql)
         return upsert_sql
 
     def _cql_upsert_from_dataframe(self, dataframe, table):
@@ -293,7 +293,7 @@ class CassandraUtil:
         ({", ".join(list(dataframe.columns.values))}) 
         VALUES ({", ".join(['?' for key in dataframe.columns.values])});
             """
-        log.info(upsert_sql)
+        log.debug(upsert_sql)
         return upsert_sql
 
     def upsert_dataframe(self, dataframe: DataFrame, table: str) -> list:
@@ -325,7 +325,7 @@ class CassandraUtil:
     @retry(wait_exponential_multiplier=_RETRY_WAIT_MULTIPLIER_MS,
            wait_exponential_max=_RETRY_WAIT_MAX_MS)
     def _execute_batch(self, batch):
-        log.info("Executing query: %s", batch)
+        log.debug("Executing query: %s", batch)
         return self._session.execute(batch, timeout=300.0)
 
     def upsert_dict(self, data: list, table: str) -> list:
@@ -379,7 +379,7 @@ class CassandraUtil:
             PRIMARY KEY ({", ".join(primary_key_column_list)}))
         {table_options_statement};
         """
-        log.info(cql)
+        log.debug(cql)
         return cql
 
     def read_dict(self, query, **kwargs) -> list:
@@ -411,7 +411,7 @@ class CassandraUtil:
             **kwargs: Kwargs to match the session.execute command in cassandra
         Returns: ResultSet
         """
-        log.info("Executing query: %s", query)
+        log.debug("Executing query: %s", query)
         if row_factory is not None:
             self._session.row_factory = row_factory
         return self._session.execute(query, **kwargs)
@@ -426,7 +426,7 @@ class CassandraUtil:
         Returns: list[BatchStatement]
         """
         batches = []
-        log.info("Preparing cassandra batches out of rows")
+        log.debug("Preparing cassandra batches out of rows")
         batches_of_tuples = _chunk_list(tuples, _CASSANDRA_BATCH_LIMIT)
         for tpl in batches_of_tuples:
             batch = self._prepare_batch(prepared_statement, tpl)

--- a/hip_data_tools/etl/athena_to_cassandra.py
+++ b/hip_data_tools/etl/athena_to_cassandra.py
@@ -1,3 +1,6 @@
+"""
+stuff
+"""
 from attr import dataclass
 
 from hip_data_tools.apache.cassandra import CassandraConnectionSettings

--- a/hip_data_tools/etl/athena_to_cassandra.py
+++ b/hip_data_tools/etl/athena_to_cassandra.py
@@ -1,5 +1,5 @@
 """
-stuff
+handle ETL of data from Athena to Cassandra
 """
 from attr import dataclass
 

--- a/hip_data_tools/etl/athena_to_cassandra.py
+++ b/hip_data_tools/etl/athena_to_cassandra.py
@@ -1,0 +1,47 @@
+from attr import dataclass
+
+from hip_data_tools.apache.cassandra import CassandraConnectionSettings
+from hip_data_tools.aws.athena import AthenaUtil
+from hip_data_tools.aws.common import AwsConnectionSettings, AwsConnectionManager
+from hip_data_tools.etl.s3_to_cassandra import S3ToCassandraSettings, S3ToCassandra
+
+
+@dataclass
+class AthenaToCassandraSettings:
+    """S3 to Cassandra ETL settings"""
+    source_database: str
+    source_table: str
+    source_connection_settings: AwsConnectionSettings
+    destination_keyspace: str
+    destination_table: str
+    destination_table_primary_keys: list
+    destination_table_options_statement: str
+    destination_batch_size: int
+    destination_connection_settings: CassandraConnectionSettings
+
+
+class AthenaToCassandra(S3ToCassandra):
+    """
+    Class to transfer parquet data from s3 to Cassandra
+    Args:
+        settings (AthenaToCassandraSettings): the settings around the etl to be executed
+    """
+
+    def __init__(self, settings: AthenaToCassandraSettings):
+        self.settings = settings
+        self._athena = AthenaUtil(
+            database=self.settings.source_database,
+            conn=AwsConnectionManager(self.settings.source_connection_settings))
+        (bucket, key) = self._athena.get_table_data_location(self.settings.source_table)
+        self.s3_settings = S3ToCassandraSettings(
+            source_bucket=bucket,
+            source_key_prefix=key,
+            source_connection_settings=self.settings.source_connection_settings,
+            destination_keyspace=self.settings.destination_keyspace,
+            destination_table=self.settings.destination_table,
+            destination_table_primary_keys=self.settings.destination_table_primary_keys,
+            destination_table_options_statement=self.settings.destination_table_options_statement,
+            destination_batch_size=self.settings.destination_batch_size,
+            destination_connection_settings=self.settings.destination_connection_settings,
+        )
+        super().__init__(self.s3_settings)

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -308,5 +308,6 @@ class TestCassandraUtil(TestCase):
         mock_cassandra_util = Mock()
         mock_cassandra_util._prepare_batch = Mock(return_value="MockBatch")
         prepared_statement = Mock()
-        actual = CassandraUtil.prepare_batches(mock_cassandra_util, prepared_statement, input)
+        actual = CassandraUtil.prepare_batches(mock_cassandra_util, prepared_statement, input,
+                                               batch_size=20)
         self.assertEqual(actual, expected)

--- a/tests/etl/s3_to_cassandra.py
+++ b/tests/etl/s3_to_cassandra.py
@@ -1,0 +1,55 @@
+import os
+import uuid
+from unittest import TestCase
+from unittest.mock import Mock
+
+from moto import mock_s3
+
+from hip_data_tools.aws.common import AwsConnectionManager, AwsConnectionSettings, AwsSecretsManager
+from hip_data_tools.aws.s3 import S3Util
+from hip_data_tools.etl.s3_to_cassandra import S3ToCassandra, S3ToCassandraSettings
+
+
+class TestS3ToCassandra(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.sample_file_location = "./test_sample_TestS3ToCassandra.txt"
+        cls.sample_file_content = str(uuid.uuid4())
+        with open(cls.sample_file_location, 'w+') as f:
+            f.write(cls.sample_file_content)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.sample_file_location)
+
+    @mock_s3
+    def test__list_source_files__should_list_the_correct_source_files_as_an_array(self):
+        test_bucket = "test"
+        test_source_key_prefix = "test_for_s3_to_cassandra"
+        aws_conn_settings = AwsConnectionSettings(
+            region="ap-southeast-2",
+            secrets_manager=AwsSecretsManager(),
+            profile=None)
+        s3 = S3Util(conn=AwsConnectionManager(aws_conn_settings), bucket=test_bucket)
+        s3.create_bucket()
+        for itr in range(3):
+            s3.upload_file(self.sample_file_location, f"{test_source_key_prefix}/{itr}.abc")
+        expected = [
+            f"{test_source_key_prefix}/0.abc",
+            f"{test_source_key_prefix}/1.abc",
+            f"{test_source_key_prefix}/2.abc", ]
+
+        util = S3ToCassandra(S3ToCassandraSettings(
+            source_bucket=test_bucket,
+            source_key_prefix=test_source_key_prefix,
+            source_connection_settings=aws_conn_settings,
+            destination_keyspace="test",
+            destination_table="test",
+            destination_table_primary_keys=[],
+            destination_table_options_statement="",
+            destination_batch_size=2,
+            destination_connection_settings=Mock(),
+        ))
+
+        actual = util.list_source_files()
+        self.assertListEqual(actual, expected)


### PR DESCRIPTION
### What changes are proposed in this PR?
---
* Athena to Cassandra wrapper that uses the S3ToCassandra utility to transfer data stored for a given athena table (in parquet) to cassandra.

### How was this tested?
---
* Integration test;
```
import logging as log
from datetime import datetime
from unittest import TestCase

from cassandra.cluster import DCAwareRoundRobinPolicy

from hip_data_tools.apache.cassandra import CassandraConnectionSettings, CassandraSecretsManager
from hip_data_tools.aws.common import AwsConnectionSettings
from hip_data_tools.common import DictKeyValueSource
from hip_data_tools.etl.athena_to_cassandra import AthenaToCassandraSettings, AthenaToCassandra

import logging
logging.basicConfig()
logging.getLogger().setLevel(logging.INFO)

def test__integration():
    settings = AthenaToCassandraSettings(
        source_database="dev",
        source_table="foo_bar",
        source_connection_settings=AwsConnectionSettings(
            region="xxxx",
            profile="default",
            secrets_manager=None,
        ),
        destination_keyspace="dev",
        destination_table="foo_bar",
        destination_table_primary_keys=["foo", "bar"],
        destination_table_options_statement="",
        destination_batch_size=10,
        destination_connection_settings=CassandraConnectionSettings(
            cluster_ips=["xxx"],
            port=9042,
            load_balancing_policy=DCAwareRoundRobinPolicy(local_dc='xxx'),
            secrets_manager=CassandraSecretsManager(
                source=DictKeyValueSource({
                    "CASSANDRA_USERNAME": 'xxx',
                    "CASSANDRA_PASSWORD": 'xxx',
                })
            ),
        )
    )
    etl = AthenaToCassandra(settings=settings)
    start = datetime.now()
    etl.create_and_upsert_all()
    end = datetime.now()
    diff = end - start
    log.warning("Took total time of %s", diff)


test__integration()
    

```

