### PR TITLE
feat: [DP-356] add ETL Utility to read s3 as df

### DIFF
--- a/hip_data_tools/etl/s3_to_cassandra.py
+++ b/hip_data_tools/etl/s3_to_cassandra.py
@@ -9,16 +9,14 @@ from cassandra.datastax.graph import Result
 
 from hip_data_tools.apache.cassandra import CassandraUtil, CassandraConnectionManager, \
     CassandraConnectionSettings
-from hip_data_tools.aws.common import AwsConnectionSettings, AwsConnectionManager
+from hip_data_tools.aws.common import AwsConnectionManager
 from hip_data_tools.aws.s3 import S3Util
+from hip_data_tools.etl.s3_to_dataframe import S3ToDataFrame, S3ToDataFrameSettings
 
 
 @dataclass
-class S3ToCassandraSettings:
+class S3ToCassandraSettings(S3ToDataFrameSettings):
     """S3 to Cassandra ETL settings"""
-    source_bucket: str
-    source_key_prefix: str
-    source_connection_settings: AwsConnectionSettings
     destination_keyspace: str
     destination_table: str
     destination_table_primary_keys: list
@@ -27,7 +25,7 @@ class S3ToCassandraSettings:
     destination_batch_size: int = 1
 
 
-class S3ToCassandra:
+class S3ToCassandra(S3ToDataFrame):
     """
     Class to transfer parquet data from s3 to Cassandra
     Args:
@@ -36,6 +34,7 @@ class S3ToCassandra:
 
     def __init__(self, settings: S3ToCassandraSettings):
         self.settings = settings
+        super().__init__(self.settings)
         self.keys_to_transfer = None
 
     def _get_cassandra_util(self):
@@ -78,16 +77,9 @@ class S3ToCassandra:
         Upsert all files from s3 sequentially into cassandra
         Returns: None
         """
-        return [self.upsert_file(key) for key in self.list_source_files()]
+        return [self._upsert_dataframe(df) for df in self._get_iterator()]
 
-    def upsert_file(self, key: str) -> List[Result]:
-        """
-        Read a parquet file from s3 and upsert the records to Cassandra
-        Args:
-            key: s3 key for the parquet file
-        Returns: None
-        """
-        data_frame = self._get_s3_util().download_parquet_as_dataframe(key=key)
+    def _upsert_dataframe(self, data_frame):
         if self.settings.destination_batch_size > 1:
             log.info("upserting batches of size %s", self.settings.destination_batch_size)
             result = self._get_cassandra_util().upsert_dataframe_in_batches(
@@ -101,13 +93,12 @@ class S3ToCassandra:
                 table=self.settings.destination_table)
         return result
 
-    def list_source_files(self):
+    def upsert_file(self, key: str) -> List[Result]:
         """
-        Lists all the files that are encompassed under the s3 location in settings
-        Returns: list[str]
+        Read a parquet file from s3 and upsert the records to Cassandra
+        Args:
+            key: s3 key for the parquet file
+        Returns: None
         """
-        if self.keys_to_transfer is None:
-            self.keys_to_transfer = self._get_s3_util().get_keys(
-                self.settings.source_key_prefix)
-            log.info("Listed and cached %s source files", len(self.keys_to_transfer))
-        return self.keys_to_transfer
+        data_frame = self.get_dataframe(key)
+        return self._upsert_dataframe(data_frame)

--- a/hip_data_tools/etl/s3_to_cassandra.py
+++ b/hip_data_tools/etl/s3_to_cassandra.py
@@ -55,8 +55,9 @@ class S3ToCassandra(S3ToDataFrame):
         Creates the destination cassandra table if not exists
         Returns: None
         """
+        files = self.list_source_files()
         data_frame = self._get_s3_util().download_parquet_as_dataframe(
-            key=self.list_source_files()[0])
+            key=files[0])
         self._get_cassandra_util().create_table_from_dataframe(
             data_frame=data_frame,
             table_name=self.settings.destination_table,

--- a/hip_data_tools/etl/s3_to_dataframe.py
+++ b/hip_data_tools/etl/s3_to_dataframe.py
@@ -31,14 +31,15 @@ class S3ToDataFrame:
         self._iterator = None
         self.settings = settings
         self.keys_to_transfer = None
+        self._processed_counter = 0
 
     def __iter__(self):
-        self.processed_counter = 0
+        self._processed_counter = 0
         return self
 
     def __next__(self) -> DataFrame:
-        data = self.get_dataframe(self.list_source_files()[self.processed_counter])
-        self.processed_counter += 1
+        data = self.get_dataframe(self.list_source_files()[self._processed_counter])
+        self._processed_counter += 1
         return data
 
     def _get_s3_util(self) -> S3Util:

--- a/hip_data_tools/etl/s3_to_dataframe.py
+++ b/hip_data_tools/etl/s3_to_dataframe.py
@@ -1,0 +1,87 @@
+"""
+Module to deal with data transfer from S3 to Cassandra
+"""
+import logging as log
+from typing import Iterator, List
+
+import pandas as pd
+from attr import dataclass
+from pandas import DataFrame
+
+from hip_data_tools.aws.common import AwsConnectionSettings, AwsConnectionManager
+from hip_data_tools.aws.s3 import S3Util
+
+
+@dataclass
+class S3ToDataFrameSettings:
+    """S3 to Cassandra ETL settings"""
+    source_bucket: str
+    source_key_prefix: str
+    source_connection_settings: AwsConnectionSettings
+
+
+class S3ToDataFrame:
+    """
+    Class to transfer parquet data from s3 to Pandas DataFrame
+    Args:
+        settings (S3ToDataFrameSettings): the settings around the etl to be executed
+    """
+
+    def __init__(self, settings: S3ToDataFrameSettings):
+        self._iterator = None
+        self.settings = settings
+        self.keys_to_transfer = None
+
+    def __iter__(self):
+        self.processed_counter = 0
+        return self
+
+    def __next__(self) -> DataFrame:
+        data = self.get_dataframe(self.list_source_files()[self.processed_counter])
+        self.processed_counter += 1
+        return data
+
+    def _get_s3_util(self) -> S3Util:
+        return S3Util(
+            bucket=self.settings.source_bucket,
+            conn=AwsConnectionManager(self.settings.source_connection_settings),
+        )
+
+    def _get_iterator(self) -> Iterator:
+        if self._iterator is None:
+            self._iterator = iter(self)
+        return self._iterator
+
+    def get_all_files_as_dataframe(self) -> DataFrame:
+        """
+        Downloads and collates all files in a given s3 dir and returns a single DataFrame
+        Returns: DataFrame
+        """
+        return pd.concat([self.get_dataframe(key) for key in self.list_source_files()])
+
+    def get_dataframe(self, key: str) -> DataFrame:
+        """
+        Read a parquet file from s3 and convert it to a parquet DataFrame
+        Args:
+            key: s3 key for the parquet file
+        Returns: None
+        """
+        return self._get_s3_util().download_parquet_as_dataframe(key=key)
+
+    def list_source_files(self) -> List[str]:
+        """
+        Lists all the files that are encompassed under the s3 location in settings
+        Returns: list[str]
+        """
+        if self.keys_to_transfer is None:
+            self.keys_to_transfer = self._get_s3_util().get_keys(
+                self.settings.source_key_prefix)
+            log.info("Listed and cached %s source files", len(self.keys_to_transfer))
+        return self.keys_to_transfer
+
+    def next(self) -> DataFrame:
+        """
+        Gets the next DataFrame from the next file on s3
+        Returns: DataFrame
+        """
+        return next(self._get_iterator())

--- a/tests/etl/test_s3_to_dtaframe.py
+++ b/tests/etl/test_s3_to_dtaframe.py
@@ -1,0 +1,111 @@
+from unittest import TestCase
+
+import pandas as pd
+from moto import mock_s3
+from pandas.util.testing import assert_frame_equal
+
+from hip_data_tools.aws.common import AwsConnectionSettings, AwsSecretsManager, AwsConnectionManager
+from hip_data_tools.aws.s3 import S3Util
+from hip_data_tools.etl.s3_to_dataframe import S3ToDataFrameSettings, S3ToDataFrame
+
+
+class TestS3ToDataFrame(TestCase):
+
+    @mock_s3
+    def test_the_etl_should_list_files_correctly(self):
+        test_bucket = "TEST_BUCKET_DEST"
+        test_key = "some/key"
+        aws_conn = AwsConnectionSettings(
+            region="ap-southeast-2",
+            secrets_manager=AwsSecretsManager(),
+            profile=None)
+        s3_util = S3Util(conn=AwsConnectionManager(aws_conn), bucket=test_bucket)
+        df1 = pd.DataFrame(dict(A=range(10000)),
+                           index=pd.date_range('20130101', periods=10000, freq='s'))
+        df2 = pd.DataFrame(dict(A=range(10000)),
+                           index=pd.date_range('20140101', periods=10000, freq='s'))
+        df3 = pd.DataFrame(dict(A=range(10000)),
+                           index=pd.date_range('20150101', periods=10000, freq='s'))
+
+        s3_util.create_bucket()
+        s3_util.upload_dataframe_as_parquet(df1, test_key, "df1")
+        s3_util.upload_dataframe_as_parquet(df2, test_key, "df2")
+        s3_util.upload_dataframe_as_parquet(df3, test_key, "df3")
+
+        settings = S3ToDataFrameSettings(
+            source_bucket=test_bucket,
+            source_key_prefix=test_key,
+            source_connection_settings=aws_conn
+
+        )
+
+        etl = S3ToDataFrame(settings)
+
+        expected_s3_files = ['some/key/df1.parquet', 'some/key/df2.parquet',
+                             'some/key/df3.parquet']
+        self.assertEqual(expected_s3_files, etl.list_source_files())
+
+    @mock_s3
+    def test_the_etl_should_download_first_file_correctly(self):
+        test_bucket = "SOME_OTHER_BUCKET"
+        test_key = "some/key"
+        aws_conn = AwsConnectionSettings(
+            region="ap-southeast-2",
+            secrets_manager=AwsSecretsManager(),
+            profile=None)
+        s3_util = S3Util(conn=AwsConnectionManager(aws_conn), bucket=test_bucket)
+        df1 = pd.DataFrame(dict(A=range(10)),
+                           index=pd.date_range('20130101', periods=10, freq='d'))
+        df2 = pd.DataFrame(dict(A=range(10, 20)),
+                           index=pd.date_range('20130111', periods=10, freq='d'))
+
+        s3_util.create_bucket()
+        s3_util.upload_dataframe_as_parquet(df1, test_key, "df1")
+        s3_util.upload_dataframe_as_parquet(df2, test_key, "df2")
+
+        settings = S3ToDataFrameSettings(
+            source_bucket=test_bucket,
+            source_key_prefix=test_key,
+            source_connection_settings=aws_conn
+
+        )
+
+        etl = S3ToDataFrame(settings)
+
+        expected = pd.DataFrame(dict(A=range(20)),
+                                index=pd.date_range('20130101', periods=20, freq='d'))
+        assert_frame_equal(expected, etl.get_all_files_as_dataframe())
+
+    @mock_s3
+    def test_the_etl_should_list_files_correctly(self):
+        test_bucket = "TEST_BUCKET_ITR"
+        test_key = "some/key"
+        aws_conn = AwsConnectionSettings(
+            region="ap-southeast-2",
+            secrets_manager=AwsSecretsManager(),
+            profile=None)
+        s3_util = S3Util(conn=AwsConnectionManager(aws_conn), bucket=test_bucket)
+        df1 = pd.DataFrame(dict(A=range(10000)),
+                           index=pd.date_range('20130101', periods=10000, freq='s'))
+        df2 = pd.DataFrame(dict(A=range(10000)),
+                           index=pd.date_range('20140101', periods=10000, freq='s'))
+        df3 = pd.DataFrame(dict(A=range(10000)),
+                           index=pd.date_range('20150101', periods=10000, freq='s'))
+
+        s3_util.create_bucket()
+        s3_util.upload_dataframe_as_parquet(df1, test_key, "df1")
+        s3_util.upload_dataframe_as_parquet(df2, test_key, "df2")
+        s3_util.upload_dataframe_as_parquet(df3, test_key, "df3")
+
+        settings = S3ToDataFrameSettings(
+            source_bucket=test_bucket,
+            source_key_prefix=test_key,
+            source_connection_settings=aws_conn
+
+        )
+
+        etl = S3ToDataFrame(settings)
+
+        assert_frame_equal(df1, etl.next())
+        assert_frame_equal(df2, etl.next())
+        assert_frame_equal(df3, etl.next())


### PR DESCRIPTION
### What changes are proposed in this PR?
---
* Adds an S3 ETL that loads data from s3 onto DataFrame, this will be used as an intermediate step for other ETLs
* Provides 3 modes of operation
-- Read all files and get a combined Dataframe
-- Read a list of files and choose which one to get as DataFrame
-- Iteratively get next File as DataFrame

### How was this tested?
---
* Unit Tests

