### PR TITLE
fix: Convert dataframe object columns to string columns

### DIFF
--- a/hip_data_tools/common.py
+++ b/hip_data_tools/common.py
@@ -207,17 +207,17 @@ def to_snake_case(column_name: str) -> str:
 def nested_list_of_dict_to_dataframe(data: List[dict]) -> DataFrame:
     flattened_dicts = [flatten_nested_dict(d) for d in data]
     df = DataFrame(data=flattened_dicts)
-    _convert_objects_to_string(df)
+    for col in list(df):
+        _convert_object_to_string(col, df)
     return df
 
 
-def _convert_objects_to_string(df):
-    for col in list(df):
-        if df[col].dtype == "object":
-            try:
-                df[col] = df[col].astype("string")
-            except ValueError:
-                df[col] = df[col].astype(str)
+def _convert_object_to_string(col, df):
+    if df[col].dtype == "object":
+        try:
+            df[col] = df[col].astype("string")
+        except ValueError:
+            df[col] = df[col].astype(str)
 
 
 def dataframe_columns_to_snake_case(data: DataFrame) -> None:

--- a/hip_data_tools/common.py
+++ b/hip_data_tools/common.py
@@ -206,7 +206,14 @@ def to_snake_case(column_name: str) -> str:
 
 def nested_list_of_dict_to_dataframe(data: List[dict]) -> DataFrame:
     flattened_dicts = [flatten_nested_dict(d) for d in data]
-    return DataFrame(data=flattened_dicts)
+    df = DataFrame(data=flattened_dicts)
+    for col in list(df):
+        if df[col].dtype == "object":
+            try:
+                df[col] = df[col].astype("string")
+            except ValueError:
+                df[col] = df[col].astype(str)
+    return df
 
 
 def dataframe_columns_to_snake_case(data: DataFrame) -> None:

--- a/hip_data_tools/common.py
+++ b/hip_data_tools/common.py
@@ -207,13 +207,17 @@ def to_snake_case(column_name: str) -> str:
 def nested_list_of_dict_to_dataframe(data: List[dict]) -> DataFrame:
     flattened_dicts = [flatten_nested_dict(d) for d in data]
     df = DataFrame(data=flattened_dicts)
+    _convert_objects_to_string(df)
+    return df
+
+
+def _convert_objects_to_string(df):
     for col in list(df):
         if df[col].dtype == "object":
             try:
                 df[col] = df[col].astype("string")
             except ValueError:
                 df[col] = df[col].astype(str)
-    return df
 
 
 def dataframe_columns_to_snake_case(data: DataFrame) -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -147,19 +147,19 @@ class TestCommon(TestCase):
         self.assertListEqual(expected, list(actual.columns.values))
 
     def test__should__convert_object_type_to_string_type__when__dataframe_is_given(self):
-        input = [
+        input_value = [
             {
                 "abc": 123,
                 "def": "qwe",
-                "fooBar": [1, 4]
+                "fooBar": None
             },
             {
                 "abc": 345,
                 "def": "wer",
-                "fooBar": [1, 2]
+                "fooBar": None
             },
         ]
-        expected = ['int64', 'string', 'object']
-        result_df = nested_list_of_dict_to_dataframe(input)
+        expected = ['int64', 'string', 'string']
+        result_df = nested_list_of_dict_to_dataframe(input_value)
         actual = [str(result_df[col].dtype) for col in list(result_df)]
         self.assertEqual(expected, actual)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -145,3 +145,21 @@ class TestCommon(TestCase):
         expected = ['abc', 'def', 'foo_bar_baz']
         actual = nested_list_of_dict_to_dataframe(input)
         self.assertListEqual(expected, list(actual.columns.values))
+
+    def test__should__convert_object_type_to_string_type__when__dataframe_is_given(self):
+        input = [
+            {
+                "abc": 123,
+                "def": "qwe",
+                "fooBar": [1, 4]
+            },
+            {
+                "abc": 345,
+                "def": "wer",
+                "fooBar": [1, 2]
+            },
+        ]
+        expected = ['int64', 'string', 'object']
+        result_df = nested_list_of_dict_to_dataframe(input)
+        actual = [str(result_df[col].dtype) for col in list(result_df)]
+        self.assertEqual(expected, actual)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,9 @@
+import urllib
+from collections import OrderedDict
 from unittest import TestCase
+
+import pandas as pd
+import requests
 
 from hip_data_tools.common import flatten_nested_dict, \
     to_snake_case, nested_list_of_dict_to_dataframe
@@ -147,18 +152,8 @@ class TestCommon(TestCase):
         self.assertListEqual(expected, list(actual.columns.values))
 
     def test__should__convert_object_type_to_string_type__when__dataframe_is_given(self):
-        input_value = [
-            {
-                "abc": 123,
-                "def": "qwe",
-                "fooBar": None
-            },
-            {
-                "abc": 345,
-                "def": "wer",
-                "fooBar": None
-            },
-        ]
+        input_value = [OrderedDict([('adGroupId', 94823864785), ('labels', 'Hello'), OrderedDict(
+            [('policyTopicEntries', []), ('reviewState', 'REVIEWED')])])]
         expected = ['int64', 'string', 'string']
         result_df = nested_list_of_dict_to_dataframe(input_value)
         actual = [str(result_df[col].dtype) for col in list(result_df)]


### PR DESCRIPTION


### What changes are proposed in this PR?
---
* Hotfix to handle adwords dataframe complex data types. Convert object type columns to string type columns.

### How was this tested?
---
* Unit tests

