### PR TITLE
fix: [DP-460] Fix how datatypes are handled for cassandra upload

### DIFF
--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -76,8 +76,7 @@ def dataframe_to_cassandra_tuples(dataframe: DataFrame) -> list:
         dataframe (DataFrame): the dataframe to be converted to a list of tuples
     Returns: list[tuple]
     """
-    return [tuple([_standardize_datatype(val) for val in row]) for index, row in
-            dataframe.iterrows()]
+    return [tuple([_standardize_datatype(val) for val in row[1:]]) for row in dataframe.itertuples()]
 
 
 def dicts_to_cassandra_tuples(data: list) -> list:

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -153,6 +153,28 @@ class TestCassandraUtil(TestCase):
         ]
         self.assertEqual(actual, expected)
 
+    def test___extract_rows_from_dataframe__should_work_with_float_and_int(self):
+        data = [
+            {
+                "example_type": 100.0,
+                "example_id": 1234,
+                "created_at": datetime.datetime(2020, 1, 22, 1, 2),
+                "description": "this is from a dict"
+            },
+            {
+                "example_type": 200.0,
+                "example_id": 5678,
+                "created_at": datetime.datetime(2020, 1, 4),
+                "description": "this is from a dict"
+            }, ]
+        df = DataFrame(data)
+        actual = dataframe_to_cassandra_tuples(df)
+        for actual_tuple in actual:
+            self.assertTrue(isinstance(actual_tuple[0], float))
+            self.assertTrue(isinstance(actual_tuple[1], int))
+            self.assertTrue(isinstance(actual_tuple[2], datetime.datetime))
+            self.assertTrue(isinstance(actual_tuple[3], str))
+
     def test__cassandra_secrets_manager_should_raise_errors_when_keys_are_not_found(self):
         def func():
             CassandraSecretsManager(username_var="SOMEUNKNOWNVAR")


### PR DESCRIPTION
### What changes are proposed in this PR?
---
* Fix the iteration of datatypes to tuples that are used for upload to Cassandra in prepared statements.
* The current method of iterrows() does not preserve the data types and converts all elements of type integer to float the use of itertuples() ensures that the types are preserved in prepared statements.

### How was this tested?
---
*  Unit tests

