### PR TITLE
refactor: target s3 prefix calculation in adwords reports to s3 util

### DIFF
--- a/hip_data_tools/etl/adwords_to_athena.py
+++ b/hip_data_tools/etl/adwords_to_athena.py
@@ -169,6 +169,12 @@ class AdWordsReportsToAthena(AdWordsReportsToS3):
 
 def get_target_prefix_with_partition_dirs(target_key_prefix: str,
                                           partition_values: list) -> str:
+    """
+    Calculate the target s3 key prefix including partition directories
+    :param target_key_prefix:
+    :param partition_values:
+    :return:
+    """
     if partition_values:
         partition_dirs = "/".join([f"{k}={v}" for k, v in partition_values])
         return f"{target_key_prefix}/{partition_dirs}"

--- a/hip_data_tools/etl/adwords_to_athena.py
+++ b/hip_data_tools/etl/adwords_to_athena.py
@@ -34,9 +34,9 @@ class AdWordsToAthena(AdWordsToS3):
     def __init__(self, settings: AdWordsToAthenaSettings):
         self.__settings = settings
         self.base_dir = settings.target_key_prefix
-        if self.__settings.is_partitioned_table:
-            partition_dirs = "/".join([f"{k}={v}" for k, v in settings.partition_values])
-            settings.target_key_prefix = f"{settings.target_key_prefix}/{partition_dirs}"
+        settings.target_key_prefix = get_target_prefix_with_partition_dirs(
+            target_key_prefix=settings.target_key_prefix,
+            partition_values=settings.partition_values)
         super().__init__(settings)
 
     def _get_athena_util(self):
@@ -99,10 +99,9 @@ class AdWordsReportsToAthena(AdWordsReportsToS3):
     def __init__(self, settings: AdWordsReportsToAthenaSettings):
         self.__settings = settings
         self.base_dir = settings.target_key_prefix
-        if self.__settings.is_partitioned_table:
-            partition_dirs = "/".join([f"{k}={v}" for k, v in settings.partition_values])
-            settings.target_key_prefix = f"{settings.target_key_prefix}/{partition_dirs}"
-        self._final_target_prefix = settings.target_key_prefix
+        self._final_target_prefix = get_target_prefix_with_partition_dirs(
+            target_key_prefix=settings.target_key_prefix,
+            partition_values=settings.partition_values)
         super().__init__(settings)
 
     def _get_athena_util(self):
@@ -166,3 +165,11 @@ class AdWordsReportsToAthena(AdWordsReportsToS3):
             "s3_dir": self.base_dir,
         }
         return athena_table_settings
+
+
+def get_target_prefix_with_partition_dirs(target_key_prefix: str,
+                                          partition_values: list) -> str:
+    if partition_values:
+        partition_dirs = "/".join([f"{k}={v}" for k, v in partition_values])
+        return f"{target_key_prefix}/{partition_dirs}"
+    return target_key_prefix

--- a/hip_data_tools/etl/adwords_to_s3.py
+++ b/hip_data_tools/etl/adwords_to_s3.py
@@ -170,6 +170,7 @@ class AdWordsReportToS3Settings:
     target_file_prefix: Optional[str]
     target_connection_settings: AwsConnectionSettings
     transformation_field_type_mask: Optional[Dict[str, np.dtype]]
+    allow_overwrite: bool
 
 
 class AdWordsReportsToS3:
@@ -219,6 +220,8 @@ class AdWordsReportsToS3:
         dataframe_columns_to_snake_case(data)
         if self.__settings.transformation_field_type_mask:
             self._mask_field_types(data)
+        if self.__settings.allow_overwrite:
+            s3u.delete_recursive(key_prefix=self.__settings.target_key_prefix)
         s3u.upload_dataframe_as_parquet(
             dataframe=data,
             key=self.__settings.target_key_prefix,

--- a/hip_data_tools/etl/adwords_to_s3.py
+++ b/hip_data_tools/etl/adwords_to_s3.py
@@ -220,8 +220,6 @@ class AdWordsReportsToS3:
         dataframe_columns_to_snake_case(data)
         if self.__settings.transformation_field_type_mask:
             self._mask_field_types(data)
-        if self.__settings.allow_overwrite:
-            s3u.delete_recursive(key_prefix=self.__settings.target_key_prefix)
         s3u.upload_dataframe_as_parquet(
             dataframe=data,
             key=self.__settings.target_key_prefix,

--- a/hip_data_tools/etl/adwords_to_s3.py
+++ b/hip_data_tools/etl/adwords_to_s3.py
@@ -170,7 +170,6 @@ class AdWordsReportToS3Settings:
     target_file_prefix: Optional[str]
     target_connection_settings: AwsConnectionSettings
     transformation_field_type_mask: Optional[Dict[str, np.dtype]]
-    allow_overwrite: bool
 
 
 class AdWordsReportsToS3:

--- a/tests/etl/test_adwords_reports_to_athena.py
+++ b/tests/etl/test_adwords_reports_to_athena.py
@@ -1,0 +1,71 @@
+from unittest import TestCase
+
+from hip_data_tools.etl.adwords_to_athena import AdWordsReportsToAthena, \
+    AdWordsReportsToAthenaSettings
+
+
+class TestAdwordsReportsToAthena(TestCase):
+
+    def test__should__return_key_prefix_with_partition_dirs__when__a_key_prefix_and_partition_values_are_given(
+            self):
+        adwords_reports_to_athena_util = AdWordsReportsToAthena(
+            AdWordsReportsToAthenaSettings(
+                source_query="",
+                source_include_zero_impressions=True,
+                source_connection_settings=None,
+                target_bucket="test-target-bucket",
+                target_key_prefix="data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly",
+                target_file_prefix="",
+                target_connection_settings=None,
+                transformation_field_type_mask=None,
+                target_database="common",
+                target_table="google_adwords__ad_performance_report__monthly",
+                target_table_ddl_progress=True,
+                is_partitioned_table=True,
+                partition_values=[("report_start_date_dim_key", "20180901"),
+                                  ("report_end_date_dim_key", "20181001")]))
+        actual = adwords_reports_to_athena_util.get_target_prefix_with_partition_dirs()
+        expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly/report_start_date_dim_key=20180901/report_end_date_dim_key=20181001"
+        self.assertEqual(expected, actual)
+
+    def test__should__return_key_prefix__when__partition_values_are_empty(
+            self):
+        adwords_reports_to_athena_util = AdWordsReportsToAthena(
+            AdWordsReportsToAthenaSettings(
+                source_query="",
+                source_include_zero_impressions=True,
+                source_connection_settings=None,
+                target_bucket="test-target-bucket",
+                target_key_prefix="data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly",
+                target_file_prefix="",
+                target_connection_settings=None,
+                transformation_field_type_mask=None,
+                target_database="common",
+                target_table="google_adwords__ad_performance_report__monthly",
+                target_table_ddl_progress=True,
+                is_partitioned_table=True,
+                partition_values=[]))
+        actual = adwords_reports_to_athena_util.get_target_prefix_with_partition_dirs()
+        expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly"
+        self.assertEqual(expected, actual)
+
+    def test__should__return_key_prefix__when__partition_values_are_None(
+            self):
+        adwords_reports_to_athena_util = AdWordsReportsToAthena(
+            AdWordsReportsToAthenaSettings(
+                source_query="",
+                source_include_zero_impressions=True,
+                source_connection_settings=None,
+                target_bucket="test-target-bucket",
+                target_key_prefix="data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly",
+                target_file_prefix="",
+                target_connection_settings=None,
+                transformation_field_type_mask=None,
+                target_database="common",
+                target_table="google_adwords__ad_performance_report__monthly",
+                target_table_ddl_progress=True,
+                is_partitioned_table=True,
+                partition_values=None))
+        actual = adwords_reports_to_athena_util.get_target_prefix_with_partition_dirs()
+        expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly"
+        self.assertEqual(expected, actual)

--- a/tests/etl/test_adwords_reports_to_s3.py
+++ b/tests/etl/test_adwords_reports_to_s3.py
@@ -5,6 +5,7 @@ import pandas as pd
 from pandas._libs.tslibs.timestamps import Timestamp
 
 from hip_data_tools.aws.s3 import S3Util
+from hip_data_tools.etl.adwords_to_athena import get_target_prefix_with_partition_dirs
 from hip_data_tools.etl.adwords_to_s3 import AdWordsReportsToS3, AdWordsReportToS3Settings
 
 
@@ -51,6 +52,31 @@ array_field        object
 num_array_filed    object
 time_field         object
 complex_field      object"""
+        self.assertEqual(expected, actual)
+
+    def test__should__return_key_prefix_with_partition_dirs__when__a_key_prefix_and_partition_values_are_given(
+            self):
+        actual = get_target_prefix_with_partition_dirs(
+            target_key_prefix="data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly",
+            partition_values=[("report_start_date_dim_key", "20180901"),
+                              ("report_end_date_dim_key", "20181001")])
+        expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly/report_start_date_dim_key=20180901/report_end_date_dim_key=20181001"
+        self.assertEqual(expected, actual)
+
+    def test__should__return_key_prefix__when__partition_values_are_empty(
+            self):
+        actual = get_target_prefix_with_partition_dirs(
+            target_key_prefix="data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly",
+            partition_values=[])
+        expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly"
+        self.assertEqual(expected, actual)
+
+    def test__should__return_key_prefix__when__partition_values_are_None(
+            self):
+        actual = get_target_prefix_with_partition_dirs(
+            target_key_prefix="data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly",
+            partition_values=None)
+        expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly"
         self.assertEqual(expected, actual)
 
     def integration_test__should__transfer_data__when__the_method_is_called(self):

--- a/tests/etl/test_adwords_reports_to_s3.py
+++ b/tests/etl/test_adwords_reports_to_s3.py
@@ -5,7 +5,6 @@ import pandas as pd
 from pandas._libs.tslibs.timestamps import Timestamp
 
 from hip_data_tools.aws.s3 import S3Util
-from hip_data_tools.etl.adwords_to_athena import get_target_prefix_with_partition_dirs
 from hip_data_tools.etl.adwords_to_s3 import AdWordsReportsToS3, AdWordsReportToS3Settings
 
 
@@ -52,31 +51,6 @@ array_field        object
 num_array_filed    object
 time_field         object
 complex_field      object"""
-        self.assertEqual(expected, actual)
-
-    def test__should__return_key_prefix_with_partition_dirs__when__a_key_prefix_and_partition_values_are_given(
-            self):
-        actual = get_target_prefix_with_partition_dirs(
-            target_key_prefix="data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly",
-            partition_values=[("report_start_date_dim_key", "20180901"),
-                              ("report_end_date_dim_key", "20181001")])
-        expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly/report_start_date_dim_key=20180901/report_end_date_dim_key=20181001"
-        self.assertEqual(expected, actual)
-
-    def test__should__return_key_prefix__when__partition_values_are_empty(
-            self):
-        actual = get_target_prefix_with_partition_dirs(
-            target_key_prefix="data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly",
-            partition_values=[])
-        expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly"
-        self.assertEqual(expected, actual)
-
-    def test__should__return_key_prefix__when__partition_values_are_None(
-            self):
-        actual = get_target_prefix_with_partition_dirs(
-            target_key_prefix="data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly",
-            partition_values=None)
-        expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly"
         self.assertEqual(expected, actual)
 
     def integration_test__should__transfer_data__when__the_method_is_called(self):

--- a/tests/etl/test_adwords_reports_to_s3.py
+++ b/tests/etl/test_adwords_reports_to_s3.py
@@ -27,8 +27,7 @@ class TestAdwordsReportsToS3(TestCase):
                                                 "array_field": np.dtype(object),
                                                 "num_array_filed": np.dtype(object),
                                                 "time_field": np.dtype(object),
-                                                "complex_field": np.dtype(object)},
-                allow_overwrite=True))
+                                                "complex_field": np.dtype(object)}))
 
         input_value_dict = {'ad_group_id': {0: 94823864785, 1: 34523864785},
                             'labels': {0: 'Hello_1', 1: 'Hello_2'},
@@ -64,8 +63,7 @@ complex_field      object"""
                 target_key_prefix="",
                 target_file_prefix="",
                 target_connection_settings=None,
-                transformation_field_type_mask=None,
-                allow_overwrite=False))
+                transformation_field_type_mask=None))
 
         input_value_dict = {'ad_group_id': {0: 94823864785, 1: 34523864785},
                             'labels': {0: 'Hello_1', 1: 'Hello_2'},

--- a/tests/etl/test_adwords_reports_to_s3.py
+++ b/tests/etl/test_adwords_reports_to_s3.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from pandas._libs.tslibs.timestamps import Timestamp
 
+from hip_data_tools.aws.s3 import S3Util
 from hip_data_tools.etl.adwords_to_s3 import AdWordsReportsToS3, AdWordsReportToS3Settings
 
 
@@ -52,3 +53,40 @@ num_array_filed    object
 time_field         object
 complex_field      object"""
         self.assertEqual(expected, actual)
+
+    def test__should__transfer_data__when__the_method_is_called(self):
+        adwords_reports_to_s3_util = AdWordsReportsToS3(
+            AdWordsReportToS3Settings(
+                source_query="",
+                source_include_zero_impressions=True,
+                source_connection_settings=None,
+                target_bucket="test-target-bucket",
+                target_key_prefix="",
+                target_file_prefix="",
+                target_connection_settings=None,
+                transformation_field_type_mask=None,
+                allow_overwrite=False))
+
+        input_value_dict = {'ad_group_id': {0: 94823864785, 1: 34523864785},
+                            'labels': {0: 'Hello_1', 1: 'Hello_2'},
+                            'tuple_field': {0: ('field_1', 'val_1'), 1: ('field_2', 'val_2')},
+                            'bool_field': {0: True, 1: False},
+                            'array_field': {0: ['["v1", "v2"]'], 1: ['[["v1", "v2"], []]']},
+                            'num_array_filed': {0: ['1', '3', '4', '5'], 1: ['1', '3', '4', '5']},
+                            'time_field': {0: Timestamp('2020-06-18 00:00:00'),
+                                           1: Timestamp('2020-06-18 00:00:00')},
+                            'complex_field': {0: [], 1: ['{"x": "hello", "y": "world"}']}}
+        data_frame = pd.DataFrame(data=input_value_dict)
+
+        def _get_report_data(self):
+            return data_frame
+
+        AdWordsReportsToS3._get_report_data = _get_report_data
+
+        def upload_dataframe_as_parquet(self, dataframe, key, file_name):
+            pass
+
+        S3Util.upload_dataframe_as_parquet = upload_dataframe_as_parquet
+
+        kwargs = {}
+        AdWordsReportsToS3.transfer(adwords_reports_to_s3_util, **kwargs)

--- a/tests/etl/test_adwords_reports_to_s3.py
+++ b/tests/etl/test_adwords_reports_to_s3.py
@@ -26,7 +26,8 @@ class TestAdwordsReportsToS3(TestCase):
                                                 "array_field": np.dtype(object),
                                                 "num_array_filed": np.dtype(object),
                                                 "time_field": np.dtype(object),
-                                                "complex_field": np.dtype(object)}))
+                                                "complex_field": np.dtype(object)},
+                allow_overwrite=True))
 
         input_value_dict = {'ad_group_id': {0: 94823864785, 1: 34523864785},
                             'labels': {0: 'Hello_1', 1: 'Hello_2'},

--- a/tests/etl/test_adwords_reports_to_s3.py
+++ b/tests/etl/test_adwords_reports_to_s3.py
@@ -54,7 +54,7 @@ time_field         object
 complex_field      object"""
         self.assertEqual(expected, actual)
 
-    def test__should__transfer_data__when__the_method_is_called(self):
+    def integration_test__should__transfer_data__when__the_method_is_called(self):
         adwords_reports_to_s3_util = AdWordsReportsToS3(
             AdWordsReportToS3Settings(
                 source_query="",
@@ -90,8 +90,3 @@ complex_field      object"""
 
         kwargs = {}
         AdWordsReportsToS3.transfer(adwords_reports_to_s3_util, **kwargs)
-
-    @classmethod
-    def tearDown(cls):
-        S3Util.upload_dataframe_as_parquet = None
-        AdWordsReportsToS3._get_report_data = None

--- a/tests/etl/test_adwords_reports_to_s3.py
+++ b/tests/etl/test_adwords_reports_to_s3.py
@@ -90,3 +90,8 @@ complex_field      object"""
 
         kwargs = {}
         AdWordsReportsToS3.transfer(adwords_reports_to_s3_util, **kwargs)
+
+    @classmethod
+    def tearDown(cls):
+        S3Util.upload_dataframe_as_parquet = None
+        AdWordsReportsToS3._get_report_data = None


### PR DESCRIPTION
### What changes are proposed in this PR?
---
* Added get_target_prefix_with_partition_dirs function with unit tests

### How was this tested?
---
* Unit tests

