### PR TITLE
fix: adwords to s3 target key prefix

### DIFF
--- a/hip_data_tools/etl/adwords_to_athena.py
+++ b/hip_data_tools/etl/adwords_to_athena.py
@@ -99,7 +99,10 @@ class AdWordsReportsToAthena(AdWordsReportsToS3):
     def __init__(self, settings: AdWordsReportsToAthenaSettings):
         self.__settings = settings
         self.base_dir = settings.target_key_prefix
-        self._final_target_prefix = self.get_target_prefix_with_partition_dirs()
+        if self.__settings.is_partitioned_table:
+            partition_dirs = "/".join([f"{k}={v}" for k, v in settings.partition_values])
+            settings.target_key_prefix = f"{settings.target_key_prefix}/{partition_dirs}"
+        self._final_target_prefix = settings.target_key_prefix
         super().__init__(settings)
 
     def _get_athena_util(self):
@@ -166,10 +169,7 @@ class AdWordsReportsToAthena(AdWordsReportsToS3):
 
     def get_target_prefix_with_partition_dirs(self) -> str:
         """
-        Calculate the target s3 key prefix including partition directories
+        Return the target s3 key prefix which includes partition directories
         Returns: modified target key prefix string
         """
-        if self.__settings.partition_values:
-            partition_dirs = "/".join([f"{k}={v}" for k, v in self.__settings.partition_values])
-            self.__settings.target_key_prefix = f"{self.__settings.target_key_prefix}/{partition_dirs}"
         return self.__settings.target_key_prefix

--- a/hip_data_tools/etl/adwords_to_athena.py
+++ b/hip_data_tools/etl/adwords_to_athena.py
@@ -171,5 +171,5 @@ class AdWordsReportsToAthena(AdWordsReportsToS3):
         """
         if self.__settings.partition_values:
             partition_dirs = "/".join([f"{k}={v}" for k, v in self.__settings.partition_values])
-            return f"{self.__settings.target_key_prefix}/{partition_dirs}"
+            self.__settings.target_key_prefix = f"{self.__settings.target_key_prefix}/{partition_dirs}"
         return self.__settings.target_key_prefix

--- a/tests/etl/test_adwords_reports_to_athena.py
+++ b/tests/etl/test_adwords_reports_to_athena.py
@@ -43,7 +43,7 @@ class TestAdwordsReportsToAthena(TestCase):
                 target_database="common",
                 target_table="google_adwords__ad_performance_report__monthly",
                 target_table_ddl_progress=True,
-                is_partitioned_table=True,
+                is_partitioned_table=False,
                 partition_values=[]))
         actual = adwords_reports_to_athena_util.get_target_prefix_with_partition_dirs()
         expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly"
@@ -64,7 +64,7 @@ class TestAdwordsReportsToAthena(TestCase):
                 target_database="common",
                 target_table="google_adwords__ad_performance_report__monthly",
                 target_table_ddl_progress=True,
-                is_partitioned_table=True,
+                is_partitioned_table=False,
                 partition_values=None))
         actual = adwords_reports_to_athena_util.get_target_prefix_with_partition_dirs()
         expected = "data/external/source=adwords/type=report_archive/database=common/table=google_adwords__ad_performance_report__monthly"


### PR DESCRIPTION
### What changes are proposed in this PR?
---
* Fixed adwords to s3 target key prefix (Files had been uploaded into the root directory skipping the partition directories)

### How was this tested?
---
* Unit tests

