### PR TITLE
feat: support composite keys as primary keys in Cassandra tables

### DIFF
--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -428,7 +428,9 @@ class CassandraUtil:
         Returns:  str
         """
         column_list = _cql_manage_column_lists(data_frame, partition_key_column_list + clustering_key_column_list)
+        # create list of partition keys
         partition_key = ["(" + ", ".join(partition_key_column_list) + ")"]
+        # create list of cluster keys (empty if none)
         cluster_keys = list(filter(None, [", ".join(clustering_key_column_list)]))
         cql = f"""
         CREATE TABLE IF NOT EXISTS {self.keyspace}.{table_name} (

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -428,12 +428,12 @@ class CassandraUtil:
         Returns:  str
         """
         column_list = _cql_manage_column_lists(data_frame, partition_key_column_list + clustering_key_column_list)
-        partition_key = "(" + ", ".join(partition_key_column_list) + ")"
-        cluster_keys = ", ".join(clustering_key_column_list)
+        partition_key = ["(" + ", ".join(partition_key_column_list) + ")"]
+        cluster_keys = [", ".join(clustering_key_column_list)]
         cql = f"""
         CREATE TABLE IF NOT EXISTS {self.keyspace}.{table_name} (
             {", ".join(column_list)},
-            PRIMARY KEY ({", ".join([partition_key,cluster_keys])})
+            PRIMARY KEY ({", ".join([partition_key + cluster_keys])})
             )
         {table_options_statement};
         """

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -112,12 +112,11 @@ class ValidationError(Exception):
 def _cql_manage_column_lists(data_frame, primary_key_column_list, partition_key_column_list):
     column_dict = get_cql_columns_from_dataframe(data_frame)
     column_list = [f"{k} {v}" for (k, v) in column_dict.items()]
-    _validate_primary_key_list(column_dict, primary_key_column_list)
-    _validate_partition_key_list(primary_key_column_list, partition_key_column_list)
+    _validate_primary_key_list(column_dict, primary_key_column_list, partition_key_column_list)
     return column_list
 
 
-def _validate_primary_key_list(column_dict, primary_key_column_list):
+def _validate_primary_key_list(column_dict, primary_key_column_list, partition_key_column_list):
     if primary_key_column_list is None or not primary_key_column_list:
         raise ValidationError("please provide at least one primary key column")
     for key in primary_key_column_list:
@@ -126,8 +125,6 @@ def _validate_primary_key_list(column_dict, primary_key_column_list):
                 f"The column {key} is not in the column list, it cannot be specified as a primary "
                 "key",
             )
-
-def _validate_partition_key_list(primary_key_column_list, partition_key_column_list):
     if partition_key_column_list is None or not partition_key_column_list:
         LOG.debug('No partition key specified. Revert to using first column from the primary key for partitioning.')
         return

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -116,6 +116,17 @@ def _cql_manage_column_lists(data_frame, primary_key_column_list, partition_key_
     return column_list
 
 
+def _validate_partition_key_list(primary_key_column_list, partition_key_column_list):
+    if partition_key_column_list is None or not partition_key_column_list:
+        LOG.debug('No partition key specified. Revert to using first column from the primary key for partitioning.')
+        return
+    for key in partition_key_column_list:
+        if key not in primary_key_column_list:
+            raise ValidationError(
+                f"The column {key} is not in the primary key list. It cannot be specified as part of the partition key",
+            )
+
+
 def _validate_primary_key_list(column_dict, primary_key_column_list, partition_key_column_list):
     if primary_key_column_list is None or not primary_key_column_list:
         raise ValidationError("please provide at least one primary key column")
@@ -125,14 +136,7 @@ def _validate_primary_key_list(column_dict, primary_key_column_list, partition_k
                 f"The column {key} is not in the column list, it cannot be specified as a primary "
                 "key",
             )
-    if partition_key_column_list is None or not partition_key_column_list:
-        LOG.debug('No partition key specified. Revert to using first column from the primary key for partitioning.')
-        return
-    for key in partition_key_column_list:
-        if key not in primary_key_column_list:
-            raise ValidationError(
-                f"The column {key} is not in the primary key list. It cannot be specified as part of the partition key",
-            )
+    _validate_partition_key_list(primary_key_column_list, partition_key_column_list)
 
 class CassandraSecretsManager(SecretsManager):
     """

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -115,7 +115,7 @@ def _cql_manage_column_lists(data_frame, primary_key_column_list, partition_key_
     _validate_partition_key_list(column_dict, primary_key_column_list, partition_key_column_list)
     return column_list
 
-def _validate_primary_key_list(column_dict, primary_key_column_list, partition_key_column_list):
+def _validate_primary_key_list(column_dict, primary_key_column_list):
     if primary_key_column_list is None or not primary_key_column_list:
         raise ValidationError("please provide at least one primary key column")
     for key in primary_key_column_list:
@@ -126,7 +126,7 @@ def _validate_primary_key_list(column_dict, primary_key_column_list, partition_k
             )
 
 def _validate_partition_key_list(column_dict, primary_key_column_list, partition_key_column_list):
-    _validate_primary_key_list(column_dict, primary_key_column_list, partition_key_column_list)
+    _validate_primary_key_list(column_dict, primary_key_column_list)
     if partition_key_column_list is None or not partition_key_column_list:
         LOG.debug('No partition key specified. Revert to using first column from the primary key for partitioning.')
         return

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -128,7 +128,7 @@ def _validate_primary_key_list(column_dict, primary_key_column_list):
 def _validate_partition_key_list(column_dict, primary_key_column_list, partition_key_column_list):
     _validate_primary_key_list(column_dict, primary_key_column_list)
     if partition_key_column_list is None or not partition_key_column_list:
-        LOG.debug(f'partition_key_column_list : {partition_key_column_list}\n partition_key_column_list : {partition_key_column_list}\nNo partition key specified. Revert to using first column from the primary key for partitioning.')
+LOG.debug("partition_key_column_list : %s\nNo partition key specified. Revert to using first column from the primary key for partitioning.", str(partition_key_column_list))
         return
     for key in partition_key_column_list:
         if key not in primary_key_column_list:

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -128,7 +128,8 @@ def _validate_primary_key_list(column_dict, primary_key_column_list):
 def _validate_partition_key_list(column_dict, primary_key_column_list, partition_key_column_list):
     _validate_primary_key_list(column_dict, primary_key_column_list)
     if partition_key_column_list is None or not partition_key_column_list:
-LOG.debug("partition_key_column_list : %s\nNo partition key specified. Revert to using first column from the primary key for partitioning.", str(partition_key_column_list))
+        LOG.debug("partition_key_column_list : %s\nNo partition key specified. Revert to using first column from the primary key for partitioning.",
+            str(partition_key_column_list))
         return
     for key in partition_key_column_list:
         if key not in primary_key_column_list:

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -433,7 +433,7 @@ class CassandraUtil:
         cql = f"""
         CREATE TABLE IF NOT EXISTS {self.keyspace}.{table_name} (
             {", ".join(column_list)},
-                PRIMARY KEY ({", ".join([partition_key,cluster_keys])})
+            PRIMARY KEY ({", ".join([partition_key,cluster_keys])})
             )
         {table_options_statement};
         """

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -131,8 +131,7 @@ def _validate_primary_key_list(column_dict, primary_key_column_list, partition_k
     for key in partition_key_column_list:
         if key not in primary_key_column_list:
             raise ValidationError(
-                f"The column {key} is not in the primary key list. It cannot be specified as part of the partition"
-                "key",
+                f"The column {key} is not in the primary key list. It cannot be specified as part of the partition key",
             )
 
 class CassandraSecretsManager(SecretsManager):
@@ -437,8 +436,8 @@ class CassandraUtil:
         """
         column_list = _cql_manage_column_lists(data_frame, primary_key_column_list, partition_key_column_list)
         # create list of partition keys from first column of the primary key if not specified
-        partition_key_column_list = partition_key_column_list if len(partition_key_column_list) > 0 \
-            else [primary_key_column_list[0]]
+        partition_key_column_list = partition_key_column_list if partition_key_column_list is not None and \
+            len(partition_key_column_list) > 0 else [primary_key_column_list[0]]
         partition_key = ["(" + ", ".join(partition_key_column_list) + ")"]
         # create list of cluster keys from the remainder of the primary key columns
         clustering_key_column_list = [x for x in primary_key_column_list if x not in partition_key_column_list]

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -129,14 +129,14 @@ def _validate_primary_key_list(column_dict, primary_key_column_list):
 
 def _validate_partition_key_list(primary_key_column_list, partition_key_column_list):
     if primary_key_column_list is None or not primary_key_column_list:
-        raise ValidationError("please provide at least one primary key column")
-    if partition_key_column_list is not None or partition_key_column_list:
-        for key in partition_key_column_list:
-            if key not in primary_key_column_list:
-                raise ValidationError(
-                    f"The column {key} is not in the primary key list. It cannot be specified as part of the partition"
-                    "key",
-                )
+        LOG.debug('No partition key specified. Revert to using first column from the primary key for partitioning.')
+        return
+    for key in partition_key_column_list:
+        if key not in primary_key_column_list:
+            raise ValidationError(
+                f"The column {key} is not in the primary key list. It cannot be specified as part of the partition"
+                "key",
+            )
 
 class CassandraSecretsManager(SecretsManager):
     """
@@ -441,7 +441,7 @@ class CassandraUtil:
         column_list = _cql_manage_column_lists(data_frame, primary_key_column_list, partition_key_column_list)
         # create list of partition keys from first column of the primary key if not specified
         partition_key_column_list = partition_key_column_list if len(partition_key_column_list) > 0 \
-            else primary_key_column_list[0]
+            else [primary_key_column_list[0]]
         partition_key = ["(" + ", ".join(partition_key_column_list) + ")"]
         # create list of cluster keys from the remainder of the primary key columns
         clustering_key_column_list = [x for x in primary_key_column_list if x not in partition_key_column_list]

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -429,7 +429,7 @@ class CassandraUtil:
         """
         column_list = _cql_manage_column_lists(data_frame, partition_key_column_list + clustering_key_column_list)
         partition_key = ["(" + ", ".join(partition_key_column_list) + ")"]
-        cluster_keys = [", ".join(clustering_key_column_list)]
+        cluster_keys = list(filter(None, [", ".join(clustering_key_column_list)]))
         cql = f"""
         CREATE TABLE IF NOT EXISTS {self.keyspace}.{table_name} (
             {", ".join(column_list)},

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -431,7 +431,7 @@ class CassandraUtil:
         # create list of partition keys
         partition_key = ["(" + ", ".join(partition_key_column_list) + ")"]
         # create list of cluster keys (empty if none)
-        cluster_keys = list(filter(None, [", ".join(clustering_key_column_list)]))
+        cluster_keys = [", ".join(clustering_key_column_list)] if len(clustering_key_column_list)>0 else []
         cql = f"""
         CREATE TABLE IF NOT EXISTS {self.keyspace}.{table_name} (
             {", ".join(column_list)},

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -128,7 +128,7 @@ def _validate_primary_key_list(column_dict, primary_key_column_list):
             )
 
 def _validate_partition_key_list(primary_key_column_list, partition_key_column_list):
-    if primary_key_column_list is None or not primary_key_column_list:
+    if partition_key_column_list is None or not partition_key_column_list:
         LOG.debug('No partition key specified. Revert to using first column from the primary key for partitioning.')
         return
     for key in partition_key_column_list:

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -128,7 +128,7 @@ def _validate_primary_key_list(column_dict, primary_key_column_list):
 def _validate_partition_key_list(column_dict, primary_key_column_list, partition_key_column_list):
     _validate_primary_key_list(column_dict, primary_key_column_list)
     if partition_key_column_list is None or not partition_key_column_list:
-        LOG.debug('No partition key specified. Revert to using first column from the primary key for partitioning.')
+        LOG.debug(f'partition_key_column_list : {partition_key_column_list}\n partition_key_column_list : {partition_key_column_list}\nNo partition key specified. Revert to using first column from the primary key for partitioning.')
         return
     for key in partition_key_column_list:
         if key not in primary_key_column_list:

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -123,7 +123,7 @@ def _validate_primary_key_list(column_dict, primary_key_column_list):
     for key in primary_key_column_list:
         if key not in column_dict.keys():
             raise ValidationError(
-                f"The column {key} is not in the column list, it cannot be specified as a primary"
+                f"The column {key} is not in the column list, it cannot be specified as a primary "
                 "key",
             )
 
@@ -132,7 +132,7 @@ def _validate_partition_key_list(primary_key_column_list, partition_key_column_l
         raise ValidationError("please provide at least one primary key column")
     if partition_key_column_list is not None or partition_key_column_list:
         for key in partition_key_column_list:
-            if key not in primary_key_column_list.keys():
+            if key not in primary_key_column_list:
                 raise ValidationError(
                     f"The column {key} is not in the primary key list. It cannot be specified as part of the partition"
                     "key",
@@ -439,7 +439,9 @@ class CassandraUtil:
         Returns:  str
         """
         column_list = _cql_manage_column_lists(data_frame, primary_key_column_list, partition_key_column_list)
-        # create list of partition keys
+        # create list of partition keys from first column of the primary key if not specified
+        partition_key_column_list = partition_key_column_list if partition_key_column_list is None
+            or not partition_key_column_list else primary_key_column_list[0]
         partition_key = ["(" + ", ".join(partition_key_column_list) + ")"]
         # create list of cluster keys (empty if none)
         clustering_key_column_list = [x for x in primary_key_column_list if x not in partition_key_column_list]

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -440,8 +440,8 @@ class CassandraUtil:
         """
         column_list = _cql_manage_column_lists(data_frame, primary_key_column_list, partition_key_column_list)
         # create list of partition keys from first column of the primary key if not specified
-        partition_key_column_list = partition_key_column_list if partition_key_column_list is None
-            or not partition_key_column_list else primary_key_column_list[0]
+        partition_key_column_list = partition_key_column_list if len(partition_key_column_list) > 0 \
+            else primary_key_column_list[0]
         partition_key = ["(" + ", ".join(partition_key_column_list) + ")"]
         # create list of cluster keys (empty if none)
         clustering_key_column_list = [x for x in primary_key_column_list if x not in partition_key_column_list]

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -443,7 +443,7 @@ class CassandraUtil:
         partition_key_column_list = partition_key_column_list if len(partition_key_column_list) > 0 \
             else primary_key_column_list[0]
         partition_key = ["(" + ", ".join(partition_key_column_list) + ")"]
-        # create list of cluster keys (empty if none)
+        # create list of cluster keys from the remainder of the primary key columns
         clustering_key_column_list = [x for x in primary_key_column_list if x not in partition_key_column_list]
         cluster_keys = [", ".join(clustering_key_column_list)] if len(clustering_key_column_list)>0 else []
         cql = f"""

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -347,7 +347,7 @@ class CassandraUtil:
         LOG.debug("Executing query: %s", batch)
         return self._session.execute(batch, timeout=300.0)
 
-    def upsert_dictonary_list_in_batches(self,
+    def upsert_dictionary_list_in_batches(self,
                                          data: List[dict],
                                          table: str,
                                          batch_size: int = 2
@@ -365,7 +365,7 @@ class CassandraUtil:
                                        batch_size)
         return self._execute_batches(batches)
 
-    def upsert_dictonary_list(self,
+    def upsert_dictionary_list(self,
                               data: List[dict],
                               table: str,
                               ) -> List[Result]:
@@ -455,7 +455,7 @@ class CassandraUtil:
         LOG.debug(cql)
         return cql
 
-    def read_as_dictonary_list(self, query: str, **kwargs) -> List[dict]:
+    def read_as_dictionary_list(self, query: str, **kwargs) -> List[dict]:
         """
         Read the results of a query in form of a list of dict
         Args:

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -2,7 +2,7 @@
 Utility for connecting to and transforming data in Cassandra clusters
 """
 import os
-from typing import List, Tuple
+from typing import List
 
 import pandas as pd
 from attr import dataclass

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -433,7 +433,7 @@ class CassandraUtil:
         cql = f"""
         CREATE TABLE IF NOT EXISTS {self.keyspace}.{table_name} (
             {", ".join(column_list)},
-            PRIMARY KEY ({", ".join([partition_key + cluster_keys])})
+            PRIMARY KEY ({", ".join(partition_key + cluster_keys)})
             )
         {table_options_statement};
         """

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -433,7 +433,7 @@ class CassandraUtil:
         cql = f"""
         CREATE TABLE IF NOT EXISTS {self.keyspace}.{table_name} (
             {", ".join(column_list)},
-            # PRIMARY KEY ({", ".join([partition_key,cluster_keys])})
+                PRIMARY KEY ({", ".join([partition_key,cluster_keys])})
             )
         {table_options_statement};
         """

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -112,20 +112,8 @@ class ValidationError(Exception):
 def _cql_manage_column_lists(data_frame, primary_key_column_list, partition_key_column_list):
     column_dict = get_cql_columns_from_dataframe(data_frame)
     column_list = [f"{k} {v}" for (k, v) in column_dict.items()]
-    _validate_primary_key_list(column_dict, primary_key_column_list, partition_key_column_list)
+    _validate_partition_key_list(column_dict, primary_key_column_list, partition_key_column_list)
     return column_list
-
-
-def _validate_partition_key_list(primary_key_column_list, partition_key_column_list):
-    if partition_key_column_list is None or not partition_key_column_list:
-        LOG.debug('No partition key specified. Revert to using first column from the primary key for partitioning.')
-        return
-    for key in partition_key_column_list:
-        if key not in primary_key_column_list:
-            raise ValidationError(
-                f"The column {key} is not in the primary key list. It cannot be specified as part of the partition key",
-            )
-
 
 def _validate_primary_key_list(column_dict, primary_key_column_list, partition_key_column_list):
     if primary_key_column_list is None or not primary_key_column_list:
@@ -136,7 +124,17 @@ def _validate_primary_key_list(column_dict, primary_key_column_list, partition_k
                 f"The column {key} is not in the column list, it cannot be specified as a primary "
                 "key",
             )
-    _validate_partition_key_list(primary_key_column_list, partition_key_column_list)
+
+def _validate_partition_key_list(column_dict, primary_key_column_list, partition_key_column_list):
+    _validate_primary_key_list(column_dict, primary_key_column_list, partition_key_column_list)
+    if partition_key_column_list is None or not partition_key_column_list:
+        LOG.debug('No partition key specified. Revert to using first column from the primary key for partitioning.')
+        return
+    for key in partition_key_column_list:
+        if key not in primary_key_column_list:
+            raise ValidationError(
+                f"The column {key} is not in the primary key list. It cannot be specified as part of the partition key",
+            )
 
 class CassandraSecretsManager(SecretsManager):
     """

--- a/hip_data_tools/etl/athena_to_cassandra.py
+++ b/hip_data_tools/etl/athena_to_cassandra.py
@@ -17,7 +17,8 @@ class AthenaToCassandraSettings:
     source_connection_settings: AwsConnectionSettings
     destination_keyspace: str
     destination_table: str
-    destination_table_primary_keys: list
+    destination_table_partition_key: list
+    destination_table_clustering_keys: list
     destination_connection_settings: CassandraConnectionSettings
     destination_table_options_statement: str = ""
     destination_batch_size: int = 1
@@ -42,7 +43,8 @@ class AthenaToCassandra(S3ToCassandra):
             source_connection_settings=self.__settings.source_connection_settings,
             destination_keyspace=self.__settings.destination_keyspace,
             destination_table=self.__settings.destination_table,
-            destination_table_primary_keys=self.__settings.destination_table_primary_keys,
+            destination_table_partition_key=self.__settings.destination_table_partition_key,
+            destination_table_clustering_keys=self.__settings.destination_table_clustering_keys,
             destination_table_options_statement=self.__settings.destination_table_options_statement,
             destination_batch_size=self.__settings.destination_batch_size,
             destination_connection_settings=self.__settings.destination_connection_settings,

--- a/hip_data_tools/etl/athena_to_cassandra.py
+++ b/hip_data_tools/etl/athena_to_cassandra.py
@@ -17,8 +17,8 @@ class AthenaToCassandraSettings:
     source_connection_settings: AwsConnectionSettings
     destination_keyspace: str
     destination_table: str
+    destination_table_primary_keys: list
     destination_table_partition_key: list
-    destination_table_clustering_keys: list
     destination_connection_settings: CassandraConnectionSettings
     destination_table_options_statement: str = ""
     destination_batch_size: int = 1
@@ -43,8 +43,8 @@ class AthenaToCassandra(S3ToCassandra):
             source_connection_settings=self.__settings.source_connection_settings,
             destination_keyspace=self.__settings.destination_keyspace,
             destination_table=self.__settings.destination_table,
+            destination_table_primary_keys=self.__settings.destination_table_primary_keys,
             destination_table_partition_key=self.__settings.destination_table_partition_key,
-            destination_table_clustering_keys=self.__settings.destination_table_clustering_keys,
             destination_table_options_statement=self.__settings.destination_table_options_statement,
             destination_batch_size=self.__settings.destination_batch_size,
             destination_connection_settings=self.__settings.destination_connection_settings,

--- a/hip_data_tools/etl/s3_to_cassandra.py
+++ b/hip_data_tools/etl/s3_to_cassandra.py
@@ -19,11 +19,8 @@ class S3ToCassandraSettings(S3ToDataFrameSettings):
     """S3 to Cassandra ETL settings"""
     destination_keyspace: str
     destination_table: str
-    # specify either partition and clustering columns (composite partition keys)
     destination_table_partition_key: list
     destination_table_clustering_keys: list
-    # or specify the primary keys columns (compound partition keys)
-    destination_table_primary_keys: list
     destination_connection_settings: CassandraConnectionSettings
     destination_table_options_statement: str = ""
     destination_batch_size: int = 1
@@ -62,24 +59,15 @@ class S3ToCassandra(S3ToDataFrame):
         files = self.list_source_files()
         data_frame = self._get_s3_util().download_parquet_as_dataframe(
             key=files[0])
-        if len(self.__settings.destination_table_partition_key) > 0:
-            # use specified partition and clustering keys
-            self._get_cassandra_util().create_table_from_dataframe(
-                data_frame=data_frame,
-                table_name=self.__settings.destination_table,
-                partition_key_column_list=self.__settings.destination_table_partition_key,
-                clustering_key_column_list=self.__settings.destination_table_clustering_keys,
-                table_options_statement=self.__settings.destination_table_options_statement,
-            )
-        else:
-            # create partition and clustering keys from primary keys
-            self._get_cassandra_util().create_table_from_dataframe(
-                data_frame=data_frame,
-                table_name=self.__settings.destination_table,
-                partition_key_column_list=self.__settings.destination_table_primary_keys[0],
-                clustering_key_column_list=self.__settings.destination_table_primary_keys[1:],
-                table_options_statement=self.__settings.destination_table_options_statement,
-            )
+        # use specified partition and clustering keys
+        self._get_cassandra_util().create_table_from_dataframe(
+            data_frame=data_frame,
+            table_name=self.__settings.destination_table,
+            partition_key_column_list=self.__settings.destination_table_partition_key,
+            clustering_key_column_list=self.__settings.destination_table_clustering_keys,
+            table_options_statement=self.__settings.destination_table_options_statement,
+        )
+
 
 
     def create_and_upsert_all(self) -> List[List[Result]]:

--- a/hip_data_tools/etl/s3_to_cassandra.py
+++ b/hip_data_tools/etl/s3_to_cassandra.py
@@ -19,8 +19,8 @@ class S3ToCassandraSettings(S3ToDataFrameSettings):
     """S3 to Cassandra ETL settings"""
     destination_keyspace: str
     destination_table: str
+    destination_table_primary_keys: list
     destination_table_partition_key: list
-    destination_table_clustering_keys: list
     destination_connection_settings: CassandraConnectionSettings
     destination_table_options_statement: str = ""
     destination_batch_size: int = 1
@@ -63,12 +63,10 @@ class S3ToCassandra(S3ToDataFrame):
         self._get_cassandra_util().create_table_from_dataframe(
             data_frame=data_frame,
             table_name=self.__settings.destination_table,
+            primary_key_column_list=self.__settings.destination_table_primary_keys,
             partition_key_column_list=self.__settings.destination_table_partition_key,
-            clustering_key_column_list=self.__settings.destination_table_clustering_keys,
             table_options_statement=self.__settings.destination_table_options_statement,
         )
-
-
 
     def create_and_upsert_all(self) -> List[List[Result]]:
         """

--- a/hip_data_tools/etl/s3_to_cassandra.py
+++ b/hip_data_tools/etl/s3_to_cassandra.py
@@ -19,6 +19,10 @@ class S3ToCassandraSettings(S3ToDataFrameSettings):
     """S3 to Cassandra ETL settings"""
     destination_keyspace: str
     destination_table: str
+    # specify either partition and clustering columns (composite partition keys)
+    destination_table_partition_key: list
+    destination_table_clustering_keys: list
+    # or specify the primary keys columns (compound partition keys)
     destination_table_primary_keys: list
     destination_connection_settings: CassandraConnectionSettings
     destination_table_options_statement: str = ""
@@ -58,12 +62,25 @@ class S3ToCassandra(S3ToDataFrame):
         files = self.list_source_files()
         data_frame = self._get_s3_util().download_parquet_as_dataframe(
             key=files[0])
-        self._get_cassandra_util().create_table_from_dataframe(
-            data_frame=data_frame,
-            table_name=self.__settings.destination_table,
-            primary_key_column_list=self.__settings.destination_table_primary_keys,
-            table_options_statement=self.__settings.destination_table_options_statement,
-        )
+        if len(self.__settings.destination_table_partition_key) > 0:
+            # use specified partition and clustering keys
+            self._get_cassandra_util().create_table_from_dataframe(
+                data_frame=data_frame,
+                table_name=self.__settings.destination_table,
+                partition_key_column_list=self.__settings.destination_table_partition_key,
+                clustering_key_column_list=self.__settings.destination_table_clustering_keys,
+                table_options_statement=self.__settings.destination_table_options_statement,
+            )
+        else:
+            # create partition and clustering keys from primary keys
+            self._get_cassandra_util().create_table_from_dataframe(
+                data_frame=data_frame,
+                table_name=self.__settings.destination_table,
+                partition_key_column_list=self.__settings.destination_table_primary_keys[0],
+                clustering_key_column_list=self.__settings.destination_table_primary_keys[1:],
+                table_options_statement=self.__settings.destination_table_options_statement,
+            )
+
 
     def create_and_upsert_all(self) -> List[List[Result]]:
         """

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -11,7 +11,7 @@ from pandas.util.testing import assert_frame_equal
 
 from hip_data_tools.apache.cassandra import CassandraUtil, dataframe_to_cassandra_tuples, \
     _standardize_datatype, dicts_to_cassandra_tuples, CassandraSecretsManager, \
-    _get_data_frame_column_types, get_cql_columns_from_dataframe
+    _get_data_frame_column_types, get_cql_columns_from_dataframe, ValidationError
 
 
 class TestCassandraUtil(TestCase):
@@ -320,7 +320,7 @@ class TestCassandraUtil(TestCase):
         """
         self.assertEqual(actual, expected)
 
-        # Test partition keys not part of the parimary key
+        # Test partition keys not part of the primary key
         actual = CassandraUtil._dataframe_to_cassandra_ddl(
             mock_cassandra_util, df,
             primary_key_column_list=["abc"],
@@ -328,7 +328,7 @@ class TestCassandraUtil(TestCase):
             table_name="test",
             table_options_statement=""
         )
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(ValidationError) as context:
             _validate_primary_key_list()
         self.assertTrue('The column abc2 is not in the primary key list. It cannot be specified as part of the partition key' in context.exception)
 

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -268,10 +268,12 @@ class TestCassandraUtil(TestCase):
         df = DataFrame(data)
         mock_cassandra_util = Mock()
         mock_cassandra_util.keyspace = "test"
+
+        # Test compound key
         actual = CassandraUtil._dataframe_to_cassandra_ddl(
             mock_cassandra_util, df,
-            destination_table_partition_key=["abc"],
-            destination_table_clustering_keys=["abc2"],
+            partition_key_column_list=["abc"],
+            clustering_key_column_list=["abc2"],
             table_name="test",
             table_options_statement=""
         )
@@ -283,10 +285,11 @@ class TestCassandraUtil(TestCase):
         """
         self.assertEqual(actual, expected)
 
+        # Test composite key
         actual = CassandraUtil._dataframe_to_cassandra_ddl(
             mock_cassandra_util, df,
-            destination_table_partition_key=["abc", "abc2"],
-            destination_table_clustering_keys=[],
+            partition_key_column_list=["abc", "abc2"],
+            clustering_key_column_list=[],
             table_name="test",
             table_options_statement="WITH comments = 'some text that describes the table'"
         )

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -280,7 +280,8 @@ class TestCassandraUtil(TestCase):
         expected = """
         CREATE TABLE IF NOT EXISTS test.test (
             abc map, abc2 bigint, abc3 double,
-            PRIMARY KEY ((abc), abc2))
+            PRIMARY KEY ((abc), abc2)
+            )
         ;
         """
         self.assertEqual(actual, expected)
@@ -296,7 +297,8 @@ class TestCassandraUtil(TestCase):
         expected = """
         CREATE TABLE IF NOT EXISTS test.test (
             abc map, abc2 bigint, abc3 double,
-            PRIMARY KEY ((abc, abc2)))
+            PRIMARY KEY ((abc, abc2))
+            )
         WITH comments = 'some text that describes the table';
         """
         self.assertEqual(actual, expected)

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -12,7 +12,7 @@ from pandas.util.testing import assert_frame_equal
 from hip_data_tools.apache.cassandra import CassandraUtil, dataframe_to_cassandra_tuples, \
     _standardize_datatype, dicts_to_cassandra_tuples, CassandraSecretsManager, \
     _get_data_frame_column_types, get_cql_columns_from_dataframe, ValidationError ,\
-    _validate_primary_key_list
+    _validate_primary_key_list, _validate_partition_key_list
 
 
 class TestCassandraUtil(TestCase):

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -303,7 +303,7 @@ class TestCassandraUtil(TestCase):
         """
         self.assertEqual(actual, expected)
 
-        # Test partition keys
+        # Test compound keys
         actual = CassandraUtil._dataframe_to_cassandra_ddl(
             mock_cassandra_util, df,
             primary_key_column_list=["abc","abc2"],
@@ -319,6 +319,18 @@ class TestCassandraUtil(TestCase):
         ;
         """
         self.assertEqual(actual, expected)
+
+        # Test partition keys not part of the parimary key
+        actual = CassandraUtil._dataframe_to_cassandra_ddl(
+            mock_cassandra_util, df,
+            primary_key_column_list=["abc"],
+            partition_key_column_list=["abc2"],
+            table_name="test",
+            table_options_statement=""
+        )
+        with self.assertRaises(Exception) as context:
+            _validate_primary_key_list()
+        self.assertTrue('The column abc2 is not in the primary key list. It cannot be specified as part of the partition key' in context.exception)
 
         # Test composite key
         actual = CassandraUtil._dataframe_to_cassandra_ddl(

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -269,11 +269,11 @@ class TestCassandraUtil(TestCase):
         mock_cassandra_util = Mock()
         mock_cassandra_util.keyspace = "test"
 
-        # Test compound key
+        # Test empty partition keys
         actual = CassandraUtil._dataframe_to_cassandra_ddl(
             mock_cassandra_util, df,
             primary_key_column_list=["abc","abc2"],
-            partition_key_column_list=["abc"],
+            partition_key_column_list=[],
             table_name="test",
             table_options_statement=""
         )
@@ -281,6 +281,40 @@ class TestCassandraUtil(TestCase):
         CREATE TABLE IF NOT EXISTS test.test (
             abc map, abc2 bigint, abc3 double,
             PRIMARY KEY ((abc), abc2)
+            )
+        ;
+        """
+        self.assertEqual(actual, expected)
+
+        # Test none in partition keys
+        actual = CassandraUtil._dataframe_to_cassandra_ddl(
+            mock_cassandra_util, df,
+            primary_key_column_list=["abc","abc2"],
+            partition_key_column_list=None,
+            table_name="test",
+            table_options_statement=""
+        )
+        expected = """
+        CREATE TABLE IF NOT EXISTS test.test (
+            abc map, abc2 bigint, abc3 double,
+            PRIMARY KEY ((abc), abc2)
+            )
+        ;
+        """
+        self.assertEqual(actual, expected)
+
+        # Test partition keys
+        actual = CassandraUtil._dataframe_to_cassandra_ddl(
+            mock_cassandra_util, df,
+            primary_key_column_list=["abc","abc2"],
+            partition_key_column_list=["abc2"],
+            table_name="test",
+            table_options_statement=""
+        )
+        expected = """
+        CREATE TABLE IF NOT EXISTS test.test (
+            abc map, abc2 bigint, abc3 double,
+            PRIMARY KEY ((abc2), abc)
             )
         ;
         """

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -280,7 +280,7 @@ class TestCassandraUtil(TestCase):
         expected = """
         CREATE TABLE IF NOT EXISTS test.test (
             abc map, abc2 bigint, abc3 double,
-            PRIMARY KEY ((abc),abc2))
+            PRIMARY KEY ((abc), abc2))
         ;
         """
         self.assertEqual(actual, expected)

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -270,28 +270,30 @@ class TestCassandraUtil(TestCase):
         mock_cassandra_util.keyspace = "test"
         actual = CassandraUtil._dataframe_to_cassandra_ddl(
             mock_cassandra_util, df,
-            primary_key_column_list=["abc"],
+            destination_table_partition_key=["abc"],
+            destination_table_clustering_keys=["abc2"],
             table_name="test",
             table_options_statement=""
         )
         expected = """
         CREATE TABLE IF NOT EXISTS test.test (
             abc map, abc2 bigint, abc3 double,
-            PRIMARY KEY (abc))
+            PRIMARY KEY ((abc),abc2))
         ;
         """
         self.assertEqual(actual, expected)
 
         actual = CassandraUtil._dataframe_to_cassandra_ddl(
             mock_cassandra_util, df,
-            primary_key_column_list=["abc", "abc2"],
+            destination_table_partition_key=["abc", "abc2"],
+            destination_table_clustering_keys=[],
             table_name="test",
             table_options_statement="WITH comments = 'some text that describes the table'"
         )
         expected = """
         CREATE TABLE IF NOT EXISTS test.test (
             abc map, abc2 bigint, abc3 double,
-            PRIMARY KEY (abc, abc2))
+            PRIMARY KEY ((abc, abc2)))
         WITH comments = 'some text that describes the table';
         """
         self.assertEqual(actual, expected)

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -224,7 +224,7 @@ class TestCassandraUtil(TestCase):
 
     def test__validate_primary_key_list__should_work(self):
         # Primary key not in column dict
-        self.assertRaises(ValidationError, _validate_primary_key_list, {"abc":1,"abc2":2}, ["abc3"], [])
+        self.assertRaises(ValidationError, _validate_primary_key_list, {"abc":1,"abc2":2}, ["abc3"])
 
 
     def test__validate_partition_key_list__should_work(self):

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -223,9 +223,9 @@ class TestCassandraUtil(TestCase):
 
     def test__validate_primary_key_list__should_work(self):
         # Primary key not in column dict
-        self.assertRaises(ValidationError, _validate_primary_key_list, ["abc","abc2"], ["abc3"], [])
+        self.assertRaises(ValidationError, _validate_primary_key_list, {"abc":1,"abc2":2}, ["abc3"], [])
         # Partition keys not part of the primary key
-        self.assertRaises(ValidationError, _validate_primary_key_list, ["abc","abc2"], ["abc"], ["abc2"])
+        self.assertRaises(ValidationError, _validate_primary_key_list, {"abc":1,"abc2":2}, ["abc"], ["abc2"])
 
 
     def test__convert_dataframe_columns_to_cassandra__should_work(self):

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -272,8 +272,8 @@ class TestCassandraUtil(TestCase):
         # Test compound key
         actual = CassandraUtil._dataframe_to_cassandra_ddl(
             mock_cassandra_util, df,
+            primary_key_column_list=["abc","abc2"],
             partition_key_column_list=["abc"],
-            clustering_key_column_list=["abc2"],
             table_name="test",
             table_options_statement=""
         )
@@ -289,8 +289,8 @@ class TestCassandraUtil(TestCase):
         # Test composite key
         actual = CassandraUtil._dataframe_to_cassandra_ddl(
             mock_cassandra_util, df,
+            primary_key_column_list=["abc", "abc2"],
             partition_key_column_list=["abc", "abc2"],
-            clustering_key_column_list=[],
             table_name="test",
             table_options_statement="WITH comments = 'some text that describes the table'"
         )

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -221,6 +221,7 @@ class TestCassandraUtil(TestCase):
                                       'abc3': 'float64',
                                       })
 
+
     def test__validate_primary_key_list__should_work(self):
         # Primary key not in column dict
         self.assertRaises(ValidationError, _validate_primary_key_list, {"abc":1,"abc2":2}, ["abc3"], [])
@@ -228,7 +229,7 @@ class TestCassandraUtil(TestCase):
 
     def test__validate_partition_key_list__should_work(self):
         # Partition keys not part of the primary key
-        self.assertRaises(ValidationError, test__validate_partition_key_list__should_work, ["abc"], ["abc2"])
+        self.assertRaises(ValidationError, _validate_partition_key_list, {"abc":1,"abc2":2}, ["abc"], ["abc2"])
 
 
     def test__convert_dataframe_columns_to_cassandra__should_work(self):

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -224,8 +224,11 @@ class TestCassandraUtil(TestCase):
     def test__validate_primary_key_list__should_work(self):
         # Primary key not in column dict
         self.assertRaises(ValidationError, _validate_primary_key_list, {"abc":1,"abc2":2}, ["abc3"], [])
+
+
+    def test__validate_partition_key_list__should_work(self):
         # Partition keys not part of the primary key
-        self.assertRaises(ValidationError, _validate_primary_key_list, {"abc":1,"abc2":2}, ["abc"], ["abc2"])
+        self.assertRaises(ValidationError, test__validate_partition_key_list__should_work, ["abc"], ["abc2"])
 
 
     def test__convert_dataframe_columns_to_cassandra__should_work(self):

--- a/tests/apache/test_cassandra.py
+++ b/tests/apache/test_cassandra.py
@@ -23,7 +23,7 @@ class TestCassandraUtil(TestCase):
         mock_result_set.current_rows = expected
         mock_cassandra_util = Mock()
         mock_cassandra_util.execute = Mock(return_value=mock_result_set)
-        actual = CassandraUtil.read_as_dictonary_list(mock_cassandra_util, "SELECT abc FROM def")
+        actual = CassandraUtil.read_as_dictionary_list(mock_cassandra_util, "SELECT abc FROM def")
         self.assertListEqual(actual, expected)
         mock_cassandra_util.execute.assert_called_once()
 

--- a/tests/etl/s3_to_cassandra.py
+++ b/tests/etl/s3_to_cassandra.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from moto import mock_s3
-import pandas as pd
 
 from hip_data_tools.aws.common import AwsConnectionManager, AwsConnectionSettings, AwsSecretsManager
 from hip_data_tools.aws.s3 import S3Util

--- a/tests/etl/s3_to_cassandra.py
+++ b/tests/etl/s3_to_cassandra.py
@@ -4,11 +4,12 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from moto import mock_s3
+import pandas as pd
 
 from hip_data_tools.aws.common import AwsConnectionManager, AwsConnectionSettings, AwsSecretsManager
 from hip_data_tools.aws.s3 import S3Util
-from hip_data_tools.etl.s3_to_cassandra import S3ToCassandra, S3ToCassandraSettings
-
+from hip_data_tools.etl.s3_to_cassandra import S3ToCassandra, S3ToCassandraSettings, CassandraUtil, CassandraConnectionManager, CassandraSecretsManager, CassandraConnectionSettings
+from cassandra.policies import DCAwareRoundRobinPolicy
 
 class TestS3ToCassandra(TestCase):
     @classmethod
@@ -45,11 +46,44 @@ class TestS3ToCassandra(TestCase):
             source_connection_settings=aws_conn_settings,
             destination_keyspace="test",
             destination_table="test",
-            destination_table_primary_keys=[],
+            destination_table_partition_key=[],
+            destination_table_clustering_keys=[],
             destination_table_options_statement="",
             destination_batch_size=2,
             destination_connection_settings=Mock(),
         ))
 
         actual = util.list_source_files()
+        self.assertListEqual(actual, expected)
+
+
+    @mock_s3
+    def test__create_table_statement__should_generate_create_table_cql(self):
+        load_balancing_policy = DCAwareRoundRobinPolicy(local_dc='AWS_VPC_AP_SOUTHEAST_2')
+        cassandra_conn_settings= CassandraConnectionManager(
+            settings = CassandraConnectionSettings(
+                cluster_ips=['127.0.0.1'],
+                port=9042,
+                load_balancing_policy=load_balancing_policy,
+                secrets_manager=CassandraSecretsManager(),
+                ssl_options = None
+            )
+        )
+        df = pd.DataFrame({'col1': ['a', 'a', 'b', 'b'], 'col2': [1, 2, 3, 4], 'col3': [5, 6, 7, 8],
+                           'col4': ['x', 'x', 'y', 'y'], 'col5': [1, 2, 1, 2], 'col6': [1, 2, 1, 2]})
+        test_table = "test"
+        test_partition_key = ['col1', 'col3']
+        test_cluster_keys = ['col2', 'col4']
+        test_columns = ['col5', 'col6']
+        test_source_key_prefix = "test_for_s3_to_cassandra"
+        util = CassandraUtil(keyspace= test_source_key_prefix, conn=cassandra_conn_settings)
+        expected = f"""
+        CREATE TABLE IF NOT EXISTS {test_source_key_prefix}.{test_table} (
+            {", ".join(test_columns)},
+                PRIMARY KEY (({", ".join(test_partition_key)}),{", ".join(test_cluster_keys)})
+            )"""
+        actual = util._dataframe_to_cassandra_ddl(data_frame=df,
+                                                  partition_key_column_list=test_partition_key,
+                                                  clustering_key_column_list=test_cluster_keys,
+                                                  table_name=test_table)
         self.assertListEqual(actual, expected)

--- a/tests/etl/s3_to_cassandra.py
+++ b/tests/etl/s3_to_cassandra.py
@@ -8,8 +8,7 @@ import pandas as pd
 
 from hip_data_tools.aws.common import AwsConnectionManager, AwsConnectionSettings, AwsSecretsManager
 from hip_data_tools.aws.s3 import S3Util
-from hip_data_tools.etl.s3_to_cassandra import S3ToCassandra, S3ToCassandraSettings, CassandraUtil, CassandraConnectionManager, CassandraSecretsManager, CassandraConnectionSettings
-from cassandra.policies import DCAwareRoundRobinPolicy
+from hip_data_tools.etl.s3_to_cassandra import S3ToCassandra, S3ToCassandraSettings
 
 class TestS3ToCassandra(TestCase):
     @classmethod
@@ -46,8 +45,8 @@ class TestS3ToCassandra(TestCase):
             source_connection_settings=aws_conn_settings,
             destination_keyspace="test",
             destination_table="test",
+            destination_table_primary_keys=[],
             destination_table_partition_key=[],
-            destination_table_clustering_keys=[],
             destination_table_options_statement="",
             destination_batch_size=2,
             destination_connection_settings=Mock(),


### PR DESCRIPTION
### Link to Github Issue
---
* NA

### What changes are proposed in this PR?
---
* refactored primary key logic to support use of [composite keys](https://docs.datastax.com/en/cql-oss/3.3/cql/cql_reference/cqlCreateTable.html?hl=create%2Ctable#refPkCol__cqlPKcomposite) when setting up tables in Apache Cassandra
* the composite key used for partitioning can be specified by providing a subset of columns from the primary key. If no partition keys are specified the first column from the primary key will be used as before (backwards compatible)
* typos in function names fixed

### How was this tested?
---
* unit tests updated and extended

