### PR TITLE
fix: typing extended and partition keys specified for sink state

### DIFF
--- a/hip_data_tools/etl/athena_to_cassandra.py
+++ b/hip_data_tools/etl/athena_to_cassandra.py
@@ -1,6 +1,7 @@
 """
 handle ETL of data from Athena to Cassandra
 """
+from typing import Optional, List
 from attr import dataclass
 
 from hip_data_tools.apache.cassandra import CassandraConnectionSettings
@@ -17,8 +18,8 @@ class AthenaToCassandraSettings:
     source_connection_settings: AwsConnectionSettings
     destination_keyspace: str
     destination_table: str
-    destination_table_primary_keys: list
-    destination_table_partition_key: list
+    destination_table_primary_keys: List[str]
+    destination_table_partition_key: Optional[List[str]]
     destination_connection_settings: CassandraConnectionSettings
     destination_table_options_statement: str = ""
     destination_batch_size: int = 1

--- a/hip_data_tools/etl/common.py
+++ b/hip_data_tools/etl/common.py
@@ -27,8 +27,8 @@ class EtlStates(Enum):
 
 class EtlSinkRecordState(Model):
     """Cassandra ORM model for the Etl Sink States"""
-    etl_signature = columns.Text(primary_key=True, required=True)
-    record_identifier = columns.Text(primary_key=True, required=True)
+    etl_signature = columns.Text(primary_key=True, partition_key=True, required=True)
+    record_identifier = columns.Text(primary_key=True, partition_key=True, required=True)
     record_state = columns.Text(required=True, default=EtlStates.Ready.value)
     state_created = columns.DateTime(required=True, default=datetime.now())
     state_last_updated = columns.DateTime(required=True, default=datetime.now())

--- a/hip_data_tools/etl/s3_to_cassandra.py
+++ b/hip_data_tools/etl/s3_to_cassandra.py
@@ -1,7 +1,7 @@
 """
 Module to deal with data transfer from S3 to Cassandra
 """
-from typing import List
+from typing import Optional, List
 
 from attr import dataclass
 from cassandra.datastax.graph import Result
@@ -19,8 +19,8 @@ class S3ToCassandraSettings(S3ToDataFrameSettings):
     """S3 to Cassandra ETL settings"""
     destination_keyspace: str
     destination_table: str
-    destination_table_primary_keys: list
-    destination_table_partition_key: list
+    destination_table_primary_keys: List[str]
+    destination_table_partition_key: Optional[List[str]]
     destination_connection_settings: CassandraConnectionSettings
     destination_table_options_statement: str = ""
     destination_batch_size: int = 1


### PR DESCRIPTION
### Link to Github Issue
---
* NA

### What changes are proposed in this PR?
---
* extend typing for data classes
* ensure both columns marked as primary key are also part of the composite partition key

### How was this tested?
---
* unit tests

