### PR TITLE
fix: undo boto version dependency pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "numpy",
         "mysql-connector-python>=8.0.11, <=8.0.18",
         "mysqlclient>=1.3.6,<1.4",
-        "boto3==1.16.63",  # fix boto version https://github.com/hipagesgroup/data-tools/issues/138
+        "boto3",
     ],
     test_suite="tests",
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "numpy",
         "mysql-connector-python>=8.0.11, <=8.0.18",
         "mysqlclient>=1.3.6,<1.4",
-        "boto3<=1.17.32", # fix boto version https://github.com/hipagesgroup/data-tools/issues/138
+        "boto3==1.16.63",  # fix boto version https://github.com/hipagesgroup/data-tools/issues/138
     ],
     test_suite="tests",
     tests_require=[


### PR DESCRIPTION
### Link to Github Issue
---
* https://github.com/hipagesgroup/data-tools/issues/138

### What changes are proposed in this PR?
---
* turns out the issue was due to bugs in the downstream usage of the package

### How was this tested?
---
* N/A

