### PR TITLE
fix: sql inspector return unique tables

### DIFF
--- a/hip_data_tools/aws/athena.py
+++ b/hip_data_tools/aws/athena.py
@@ -410,7 +410,7 @@ class SqlInspector:
 
     def extract_tables_from_explaination(self):
         """
-        Extracts the table references from the explaination and deposits the
+        Extracts the unique table references from the explaination and deposits the
         table references in self.table_schema_entries
 
         Returns: None
@@ -424,7 +424,9 @@ class SqlInspector:
         for row in explaination_rows:
             for data in row['Data']:
                 refs = self.parse_table_entries(data['VarCharValue'])
-                self.table_schema_entries.extend(refs)
+                for table_entry in refs:
+                    if table_entry not in self.table_schema_entries:
+                        self.table_schema_entries.extend(refs)
 
     @staticmethod
     def parse_table_entries(explain_entries: str) -> List[dict]:

--- a/tests/aws/resources/explained_queries.py
+++ b/tests/aws/resources/explained_queries.py
@@ -1,58 +1,231 @@
-SIMPLE_SELECT_EXPLAINED_QUERY = \
-    {'ResponseMetadata': {'HTTPHeaders': {'connection': 'keep-alive',
-                                          'content-length': '33',
-                                          'content-type':
-                                              'application/x-amz-json-1.1',
-                                          'date': 'Fri, 09 Jul 2021 05:34:59 '
-                                                  'GMT',
-                                          'x-amzn-requestid': 'xxx'},
-                          'HTTPStatusCode': 200,
-                          'RequestId': 'xxxx',
-                          'RetryAttempts': 0},
-     'ResultSet': {'ResultSetMetadata': {'ColumnInfo': [{'CaseSensitive': True,
-                                                         'CatalogName': 'hive',
-                                                         'Label': 'Query Plan',
-                                                         'Name': 'Query Plan',
-                                                         'Nullable': 'UNKNOWN',
-                                                         'Precision': 781,
-                                                         'Scale': 0,
-                                                         'SchemaName': '',
-                                                         'TableName': '',
-                                                         'Type': 'varchar'}]},
-                   'Rows': [{'Data': [{'VarCharValue': 'Query Plan'}]},
-                            {'Data': [
-                                {'VarCharValue': '- Output[col1, col2] => '
-                                                 '[[col1, col2]]'}]},
-                            {'Data': [
-                                {'VarCharValue': '    - Limit[10] => [[col1, '
-                                                 'col2]]'}]},
-                            {'Data': [{'VarCharValue': '        - '
-                                                       'LocalExchange[SINGLE] '
-                                                       '() '
-                                                       '=> [[col1, col2]]'}]},
-                            {'Data': [{'VarCharValue': '            - '
-                                                       'RemoteExchange['
-                                                       'GATHER] => '
-                                                       '[[col1, col2]]'}]},
-                            {'Data': [{'VarCharValue': '                - '
-                                                       'LimitPartial[10] => '
-                                                       '[[col1, col2]]'}]},
-                            {'Data': [{'VarCharValue': '                    - '
-                                                       'TableScan['
-                                                       'awsdatacatalog:HiveTableHandle{schemaName=foo, '
-                                                       'tableName=bar, '
-                                                       'analyzePartitionValues=Optional.empty}] '
-                                                       '=> [[col1, col2]]'}]},
-                            {'Data': [
-                                {'VarCharValue': '                            '
-                                                 'LAYOUT: foo.bar'}]},
-                            {'Data': [
-                                {'VarCharValue': '                            '
-                                                 'col1 := '
-                                                 'col1:bigint:1:REGULAR'}]},
-                            {'Data': [
-                                {'VarCharValue': '                            '
-                                                 'col2 := '
-                                                 'col2:bigint:0:REGULAR'}]},
-                            {'Data': [{'VarCharValue': ''}]},
-                            {'Data': [{'VarCharValue': ''}]}]}}
+SIMPLE_SELECT_EXPLAINED_QUERY = {
+    "ResponseMetadata": {
+        "HTTPHeaders": {
+            "connection": "keep-alive",
+            "content-length": "33",
+            "content-type": "application/x-amz-json-1.1",
+            "date": "Fri, 09 Jul 2021 05:34:59 " "GMT",
+            "x-amzn-requestid": "xxx",
+        },
+        "HTTPStatusCode": 200,
+        "RequestId": "xxxx",
+        "RetryAttempts": 0,
+    },
+    "ResultSet": {
+        "ResultSetMetadata": {
+            "ColumnInfo": [
+                {
+                    "CaseSensitive": True,
+                    "CatalogName": "hive",
+                    "Label": "Query Plan",
+                    "Name": "Query Plan",
+                    "Nullable": "UNKNOWN",
+                    "Precision": 781,
+                    "Scale": 0,
+                    "SchemaName": "",
+                    "TableName": "",
+                    "Type": "varchar",
+                }
+            ]
+        },
+        "Rows": [
+            {"Data": [{"VarCharValue": "Query Plan"}]},
+            {"Data": [{"VarCharValue": "- Output[col1, col2] => " "[[col1, col2]]"}]},
+            {"Data": [{"VarCharValue": "    - Limit[10] => [[col1, " "col2]]"}]},
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "        - "
+                        "LocalExchange[SINGLE] "
+                        "() "
+                        "=> [[col1, col2]]"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "            - "
+                        "RemoteExchange["
+                        "GATHER] => "
+                        "[[col1, col2]]"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "                - "
+                        "LimitPartial[10] => "
+                        "[[col1, col2]]"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "                    - "
+                        "TableScan["
+                        "awsdatacatalog:HiveTableHandle{schemaName=foo, "
+                        "tableName=bar, "
+                        "analyzePartitionValues=Optional.empty}] "
+                        "=> [[col1, col2]]"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "                    - "
+                        "TableScan["
+                        "awsdatacatalog:HiveTableHandle{schemaName=baz, "
+                        "tableName=qux, "
+                        "analyzePartitionValues=Optional.empty}] "
+                        "=> [[col1, col2]]"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {"VarCharValue": "                            " "LAYOUT: foo.bar"}
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "                            "
+                        "col1 := "
+                        "col1:bigint:1:REGULAR"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "                            "
+                        "col2 := "
+                        "col2:bigint:0:REGULAR"
+                    }
+                ]
+            },
+            {"Data": [{"VarCharValue": ""}]},
+            {"Data": [{"VarCharValue": ""}]},
+        ],
+    },
+}
+
+SIMPLE_SELECT_EXPLAINED_SELF_JOIN_QUERY = {
+    "ResponseMetadata": {
+        "HTTPHeaders": {
+            "connection": "keep-alive",
+            "content-length": "33",
+            "content-type": "application/x-amz-json-1.1",
+            "date": "Fri, 09 Jul 2021 05:34:59 " "GMT",
+            "x-amzn-requestid": "xxx",
+        },
+        "HTTPStatusCode": 200,
+        "RequestId": "xxxx",
+        "RetryAttempts": 0,
+    },
+    "ResultSet": {
+        "ResultSetMetadata": {
+            "ColumnInfo": [
+                {
+                    "CaseSensitive": True,
+                    "CatalogName": "hive",
+                    "Label": "Query Plan",
+                    "Name": "Query Plan",
+                    "Nullable": "UNKNOWN",
+                    "Precision": 781,
+                    "Scale": 0,
+                    "SchemaName": "",
+                    "TableName": "",
+                    "Type": "varchar",
+                }
+            ]
+        },
+        "Rows": [
+            {"Data": [{"VarCharValue": "Query Plan"}]},
+            {"Data": [{"VarCharValue": "- Output[col1, col2] => " "[[col1, col2]]"}]},
+            {"Data": [{"VarCharValue": "    - Limit[10] => [[col1, " "col2]]"}]},
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "        - "
+                        "LocalExchange[SINGLE] "
+                        "() "
+                        "=> [[col1, col2]]"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "            - "
+                        "RemoteExchange["
+                        "GATHER] => "
+                        "[[col1, col2]]"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "                - "
+                        "LimitPartial[10] => "
+                        "[[col1, col2]]"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "                    - "
+                        "TableScan["
+                        "awsdatacatalog:HiveTableHandle{schemaName=foo, "
+                        "tableName=bar, "
+                        "analyzePartitionValues=Optional.empty}] "
+                        "=> [[col1, col2]]"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "                    - "
+                        "TableScan["
+                        "awsdatacatalog:HiveTableHandle{schemaName=foo, "
+                        "tableName=bar, "
+                        "analyzePartitionValues=Optional.empty}] "
+                        "=> [[col1, col2]]"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {"VarCharValue": "                            " "LAYOUT: foo.bar"}
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "                            "
+                        "col1 := "
+                        "col1:bigint:1:REGULAR"
+                    }
+                ]
+            },
+            {
+                "Data": [
+                    {
+                        "VarCharValue": "                            "
+                        "col2 := "
+                        "col2:bigint:0:REGULAR"
+                    }
+                ]
+            },
+            {"Data": [{"VarCharValue": ""}]},
+            {"Data": [{"VarCharValue": ""}]},
+        ],
+    },
+}

--- a/tests/aws/test_athena.py
+++ b/tests/aws/test_athena.py
@@ -281,9 +281,9 @@ class TestAthenaUtil(TestCase):
 class TestSqlInspector(TestCase):
 
     def test__sql_inspector__should__append_explain_statement_to_query(self):
-        expected_values = [{'schemaName': 'foo', 'tableName': 'bar'}]
+        expected_values = [{'schemaName': 'foo', 'tableName': 'bar'}, {'schemaName': 'baz', 'tableName': 'qux'}]
 
-        query = """SELECT col1, col2 FROM foo.bar"""
+        query = """SELECT col1, col2 FROM foo.bar INNER JOIN baz.qux"""
 
         sql_inspector = SqlInspector(query=query,
                                      athena_util=


### PR DESCRIPTION
### Link to Github Issue
---

### What changes are proposed in this PR?
---
This PR extracts the unique table references from the query explanation by checking whether a dictionary with a particular key/value already exists in the list

### How was this tested?
---
A `test__sql_inspector__should__identify_unique_tables_used_by_query` is created to identity unique tables. 

![image](https://user-images.githubusercontent.com/39094864/127242365-67c29ee8-edcb-41f6-b5b0-fc43ab4096ab.png)

Moreover, `test__sql_inspector__should__identify_tables_used_by_query` is refactored to test multiple tables.

![image](https://user-images.githubusercontent.com/39094864/127242329-88a21ae2-a5b4-40b9-8088-0fb4ce552a62.png)


