### PR TITLE
feat: Add adwords to athena table schema overwrite

### DIFF
--- a/hip_data_tools/etl/adwords_to_athena.py
+++ b/hip_data_tools/etl/adwords_to_athena.py
@@ -22,7 +22,7 @@ class AdWordsToAthenaSettings(AdWordsToS3Settings):
     target_table_ddl_progress: bool
     is_partitioned_table: bool
     partition_values: Optional[List[Tuple[str, Any]]]
-    master_schema: Optional[List[dict]]
+    athena_columns: Optional[List[dict]]
 
 
 class AdWordsToAthena(AdWordsToS3):
@@ -73,12 +73,15 @@ class AdWordsToAthena(AdWordsToS3):
             "storage_format_selector": "parquet",
             "encryption": False,
             "table": self.__settings.target_table,
-            "columns": self.__settings.master_schema if self.__settings.master_schema else get_athena_columns_from_dataframe(
-                data),
+            "columns": self.__get_athena_columns(data),
             "s3_bucket": self.__settings.target_bucket,
             "s3_dir": self.base_dir,
         }
         return athena_table_settings
+
+    def __get_athena_columns(self, data):
+        return self.__settings.athena_columns if self.__settings.athena_columns else get_athena_columns_from_dataframe(
+            data)
 
 
 @dataclass

--- a/hip_data_tools/etl/adwords_to_athena.py
+++ b/hip_data_tools/etl/adwords_to_athena.py
@@ -82,8 +82,7 @@ class AdWordsToAthena(AdWordsToS3):
     def __get_athena_columns(self, data):
         if self.__settings.athena_columns:
             return self.__settings.athena_columns
-        else:
-            return get_athena_columns_from_dataframe(data)
+        return get_athena_columns_from_dataframe(data)
 
 
 @dataclass

--- a/hip_data_tools/etl/adwords_to_athena.py
+++ b/hip_data_tools/etl/adwords_to_athena.py
@@ -80,8 +80,10 @@ class AdWordsToAthena(AdWordsToS3):
         return athena_table_settings
 
     def __get_athena_columns(self, data):
-        return self.__settings.athena_columns if self.__settings.athena_columns else get_athena_columns_from_dataframe(
-            data)
+        if self.__settings.athena_columns:
+            return self.__settings.athena_columns
+        else:
+            return get_athena_columns_from_dataframe(data)
 
 
 @dataclass

--- a/hip_data_tools/etl/adwords_to_athena.py
+++ b/hip_data_tools/etl/adwords_to_athena.py
@@ -22,6 +22,7 @@ class AdWordsToAthenaSettings(AdWordsToS3Settings):
     target_table_ddl_progress: bool
     is_partitioned_table: bool
     partition_values: Optional[List[Tuple[str, Any]]]
+    master_schema: Optional[List[dict]]
 
 
 class AdWordsToAthena(AdWordsToS3):
@@ -72,7 +73,8 @@ class AdWordsToAthena(AdWordsToS3):
             "storage_format_selector": "parquet",
             "encryption": False,
             "table": self.__settings.target_table,
-            "columns": get_athena_columns_from_dataframe(data),
+            "columns": self.__settings.master_schema if self.__settings.master_schema else get_athena_columns_from_dataframe(
+                data),
             "s3_bucket": self.__settings.target_bucket,
             "s3_dir": self.base_dir,
         }

--- a/tests/etl/adwords_to_athena.py
+++ b/tests/etl/adwords_to_athena.py
@@ -220,7 +220,7 @@ class TestAdwordsToS3(TestCase):
         mock_util = Mock()
         mock_util._AdWordsToAthena__settings.is_partitioned_table = False
         mock_util._AdWordsToAthena__settings.target_table = 'test_athena_table'
-        mock_util._AdWordsToAthena__settings.master_schema = [
+        mock_util._AdWordsToAthena__settings.athena_columns = [
             {'column': 'field_1', 'type': 'STRING'},
             {'column': 'field_2', 'type': 'BIGINT'},
             {'column': 'field_3', 'type': 'STRING'},
@@ -261,7 +261,7 @@ class TestAdwordsToS3(TestCase):
         mock_util = Mock()
         mock_util._AdWordsToAthena__settings.is_partitioned_table = False
         mock_util._AdWordsToAthena__settings.target_table = 'test_athena_table'
-        mock_util._AdWordsToAthena__settings.master_schema = None
+        mock_util._AdWordsToAthena__settings.athena_columns = None
         mock_util._AdWordsToAthena__settings.target_bucket = 'test-bucket'
         mock_util.base_dir = 'data/'
         actual = AdWordsToAthena._construct_athena_table_settings(mock_util, data=DataFrame(

--- a/tests/etl/adwords_to_athena.py
+++ b/tests/etl/adwords_to_athena.py
@@ -216,7 +216,7 @@ class TestAdwordsToS3(TestCase):
 
         self.assertEqual(expected, len(actual["ResultSet"]["Rows"]))
 
-    def test__should__create_athena_table_settings__when__the_master_schema_is_given(self):
+    def test__should__create_athena_table_settings__when__the_athena_columns_are_given(self):
         mock_util = Mock()
         mock_util._AdWordsToAthena__settings.is_partitioned_table = False
         mock_util._AdWordsToAthena__settings.target_table = 'test_athena_table'
@@ -257,7 +257,7 @@ class TestAdwordsToS3(TestCase):
 
         self.assertEqual(expected, actual)
 
-    def test__should__create_athena_table_settings__when__the_master_schema_is_not_given(self):
+    def test__should__create_athena_table_settings__when__the_athena_columns_are_not_given(self):
         mock_util = Mock()
         mock_util._AdWordsToAthena__settings.is_partitioned_table = False
         mock_util._AdWordsToAthena__settings.target_table = 'test_athena_table'


### PR DESCRIPTION

### What changes are proposed in this PR?
---
* Add the capability to provide the Athena columns to overwrite the Athena schema generated from the dataframe in the adwords to Athena utility 

### How was this tested?
---
* Unit tests

