### PR TITLE
chore: patch broken circleci build step [dp-1412]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,10 +162,11 @@ jobs:
             twine upload dist/*
   semantic_release:
     docker:
-      - image: cimg/node:10
+      - image: cimg/node:18.0.0
     steps:
       - *restore_repo
       - checkout
+      - run: node --version
       - *save_repo
       - attach_workspace:
           at: .


### PR DESCRIPTION
Patching broken build step from new cimg (CircleCI v2 docker images)

### Link to Github Issue
---
https://hipagesgroup.atlassian.net/browse/DP-1452

### What changes are proposed in this PR?
---
* CircleCI build config

### How was this tested?
---
* Can only be tested in Circle CI, ref to documentation https://circleci.com/developer/images/image/cimg/node

