### PR TITLE
fix: set the consistency level in connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pip-delete-this-directory.txt
 
 # Env
 venv
+.venv/*
 .env
 .envrc
 env/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ from cassandra.policies import DCAwareRoundRobinPolicy
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.management import sync_table
 from cassandra.cqlengine.models import Model
+from cassandra import ConsistencyLevel
 
 load_balancing_policy = DCAwareRoundRobinPolicy(local_dc='AWS_VPC_AP_SOUTHEAST_2')
 
@@ -83,7 +84,8 @@ conn = CassandraConnectionManager(
         cluster_ips=["1.1.1.1", "2.2.2.2"],
         port=9042,
         load_balancing_policy=load_balancing_policy,
-    )
+    ),
+    consistency_level=ConsistencyLevel.LOCAL_QUORUM
 )
 
 conn = CassandraConnectionManager(
@@ -93,7 +95,8 @@ conn = CassandraConnectionManager(
         load_balancing_policy=load_balancing_policy,
         secrets_manager=CassandraSecretsManager(
         username_var="MY_CUSTOM_USERNAME_ENV_VAR"),
-    )
+    ),
+    consistency_level=ConsistencyLevel.LOCAL_ONE
 )
 
 # For running Cassandra model operations

--- a/hip_data_tools/apache/cassandra.py
+++ b/hip_data_tools/apache/cassandra.py
@@ -204,7 +204,7 @@ class CassandraConnectionManager:
         for connecting to a cluster
     """
 
-    def __init__(self, settings: CassandraConnectionSettings):
+    def __init__(self, settings: CassandraConnectionSettings, consistency_level: ConsistencyLevel = ConsistencyLevel.LOCAL_ONE):
         self._settings = settings
         self.cluster = None
         self.session = None
@@ -212,7 +212,7 @@ class CassandraConnectionManager:
             username=self._settings.secrets_manager.username,
             password=self._settings.secrets_manager.password,
         )
-        self.consistency_level = ConsistencyLevel.LOCAL_QUORUM
+        self.consistency_level = consistency_level
 
     def get_cluster(self) -> Cluster:
         """
@@ -236,7 +236,7 @@ class CassandraConnectionManager:
         """
         if self.session is None:
             self.session = self.get_cluster().connect(keyspace)
-
+            self.session.default_consistency_level = self.consistency_level
         return self.session
 
     def setup_connection(self, default_keyspace) -> None:

--- a/hip_data_tools/etl/s3_to_cassandra.py
+++ b/hip_data_tools/etl/s3_to_cassandra.py
@@ -5,6 +5,7 @@ from typing import Optional, List
 
 from attr import dataclass
 from cassandra.datastax.graph import Result
+from cassandra import ConsistencyLevel
 
 from hip_data_tools.apache.cassandra import CassandraUtil, CassandraConnectionManager, \
     CassandraConnectionSettings
@@ -42,7 +43,7 @@ class S3ToCassandra(S3ToDataFrame):
         return CassandraUtil(
             keyspace=self.__settings.destination_keyspace,
             conn=CassandraConnectionManager(
-                settings=self.__settings.destination_connection_settings),
+                settings=self.__settings.destination_connection_settings,consistency_level=ConsistencyLevel.LOCAL_QUORUM),
         )
 
     def _get_s3_util(self):


### PR DESCRIPTION
### Link to Github Issue
---

### What changes are proposed in this PR?
---
Add additional argument consistency level.This is to have flexibility while connecting to different cassandra instances.

### How was this tested?
---
Tested locally and the integration tests are passing.

