### PR TITLE
fix: [DAE-341] upgrade twine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
           name: Install Python Dependencies (with pip)
           command: |
             . venv/bin/activate
-            pip3 install setuptools wheel "twine<5.0.0" pbr poetry
+            pip3 install setuptools wheel "twine==5.1.1" pbr poetry
       - run:
           name: Install Python Dependencies (with poetry)
           command: |


### PR DESCRIPTION
https://hipagesgroup.atlassian.net/browse/DAE-341
---
* 

### What changes are proposed in this PR?
The previous PR merged but got failed to upload in pypi upgrade twine, so we needed to upgrade twine version to sync with python 3.12 
https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.12.txt

<img width="1305" height="429" alt="Screenshot 2025-11-18 at 2 41 58 pm" src="https://github.com/user-attachments/assets/0f0bca30-2bcd-4038-88f7-a6f65a181fe8" />

---
*

### How was this tested?
---
* 

