### PR TITLE
chore: update backstage catalog entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Link to data-tools in hipages Developer Portal, Component: data-tools](https://backyard.k8s.hipages.com.au/api/badges/entity/default/Component/data-tools/badge/pingback "Link to data-tools in hipages Developer Portal")](https://backyard.k8s.hipages.com.au/catalog/default/Component/data-tools)
-[![Entity owner badge, owner: data-analytics-engineering](https://backyard.k8s.hipages.com.au/api/badges/entity/default/Component/data-tools/badge/owner "Entity owner badge")](https://backyard.k8s.hipages.com.au/catalog/default/Component/data-tools)
+[![Link to data-tools-library in hipages Developer Portal, Component: data-tools-library](https://backyard.k8s.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/pingback "Link to data-tools-library in hipages Developer Portal")](https://backyard.k8s.hipages.com.au/catalog/default/component/data-tools-library)
+[![Entity owner badge, owner: data-analytics-engineering](https://backyard.k8s.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/owner "Entity owner badge")](https://backyard.k8s.hipages.com.au/catalog/default/component/data-tools-library)
 # hip-data-tools
 © Hipages Group Pty Ltd 2019-2022
 

--- a/catalog/apps/data-tools-library.yaml
+++ b/catalog/apps/data-tools-library.yaml
@@ -10,6 +10,7 @@ metadata:
     the hipages data platform.
   annotations:
     github.com/project-slug: hipagesgroup/data-tools
+    github.com/team-slug: hipagesgroup/datascience
   tags:
     - repo
     - python


### PR DESCRIPTION
## Summary
- Fix stale README Backyard badges: updated badge URLs from old `data-tools` to correct `data-tools-library` entity name
- Add missing `github.com/team-slug: hipagesgroup/datascience` annotation to the Component entity

## Test plan
- [ ] Backyard badges in README resolve to the correct `data-tools-library` Component entity
- [ ] Component entity appears in Backyard with correct team link