### PR TITLE
chore: update backstage catalog entities

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,5 +5,4 @@ metadata:
   description: Catalog entities for data-tools.
 spec:
   targets:
-    - ./catalog/*.yaml
     - ./catalog/**/*.yaml

--- a/catalog/apps/data-tools-library.yaml
+++ b/catalog/apps/data-tools-library.yaml
@@ -10,7 +10,7 @@ metadata:
     the hipages data platform.
   annotations:
     github.com/project-slug: hipagesgroup/data-tools
-    github.com/team-slug: hipagesgroup/datascience
+    github.com/team-slug: hipagesgroup/data-platform
   tags:
     - repo
     - python


### PR DESCRIPTION
## Summary

- Fix \`github.com/team-slug\` annotation: was \`hipagesgroup/datascience\`, updated to \`hipagesgroup/data-platform\` to match \`.github/CODEOWNERS\`
- Remove stale \`./catalog/*.yaml\` Location target — no YAML files exist directly in \`catalog/\` (only in \`catalog/apps/\`), causing a \`NotFoundError\` that was preventing the entity from appearing in Backyard

## Test plan
- [ ] Entity \`data-tools-library\` appears in Backyard after merge