### PR TITLE
chore: move ownership to data-platform (FY27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Link to data-tools-library in hipages Developer Portal, Component: data-tools-library](https://backyard.k8s.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/pingback "Link to data-tools-library in hipages Developer Portal")](https://backyard.k8s.hipages.com.au/catalog/default/component/data-tools-library)
-[![Entity owner badge, owner: data-platform](https://backyard.k8s.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/owner "Entity owner badge")](https://backyard.k8s.hipages.com.au/catalog/default/component/data-tools-library)
+[![Link to data-tools-library in hipages Developer Portal, Component: data-tools-library](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/pingback "Link to data-tools-library in hipages Developer Portal")](https://backyard.prod.hipages.com.au/catalog/default/component/data-tools-library)
+[![Entity owner badge, owner: data-platform](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/owner "Entity owner badge")](https://backyard.prod.hipages.com.au/catalog/default/component/data-tools-library)
 # hip-data-tools
 © Hipages Group Pty Ltd 2019-2022
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Link to data-tools-library in hipages Developer Portal, Component: data-tools-library](https://backyard.k8s.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/pingback "Link to data-tools-library in hipages Developer Portal")](https://backyard.k8s.hipages.com.au/catalog/default/component/data-tools-library)
-[![Entity owner badge, owner: data-analytics-engineering](https://backyard.k8s.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/owner "Entity owner badge")](https://backyard.k8s.hipages.com.au/catalog/default/component/data-tools-library)
+[![Entity owner badge, owner: data-platform](https://backyard.k8s.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/owner "Entity owner badge")](https://backyard.k8s.hipages.com.au/catalog/default/component/data-tools-library)
 # hip-data-tools
 © Hipages Group Pty Ltd 2019-2022
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Link to data-tools-library in hipages Developer Portal, Component: data-tools-library](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/pingback "Link to data-tools-library in hipages Developer Portal")](https://backyard.prod.hipages.com.au/catalog/default/component/data-tools-library)
-[![Entity owner badge, owner: data-platform](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/owner "Entity owner badge")](https://backyard.prod.hipages.com.au/catalog/default/component/data-tools-library)
+[![Link to data-tools-library in hipages Developer Portal, Component: data-tools-library](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/pingback "Link to data-tools-library in hipages Developer Portal")](https://backyard.internal.prod.hipages.com.au/catalog/default/component/data-tools-library)
+[![Entity owner badge, owner: data-platform](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/owner "Entity owner badge")](https://backyard.internal.prod.hipages.com.au/catalog/default/component/data-tools-library)
 # hip-data-tools
 © Hipages Group Pty Ltd 2019-2022
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Link to data-tools-library in hipages Developer Portal, Component: data-tools-library](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/pingback "Link to data-tools-library in hipages Developer Portal")](https://backyard.internal.prod.hipages.com.au/catalog/default/component/data-tools-library)
-[![Entity owner badge, owner: data-platform](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/owner "Entity owner badge")](https://backyard.internal.prod.hipages.com.au/catalog/default/component/data-tools-library)
+[![Link to data-tools-library in hipages Developer Portal, Component: data-tools-library](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/pingback "Link to data-tools-library in hipages Developer Portal")](https://backyard.prod.hipages.com.au/catalog/default/component/data-tools-library)
+[![Entity owner badge, owner: data-platform](https://backyard.prod.hipages.com.au/api/badges/entity/default/component/data-tools-library/badge/owner "Entity owner badge")](https://backyard.prod.hipages.com.au/catalog/default/component/data-tools-library)
 # hip-data-tools
 © Hipages Group Pty Ltd 2019-2022
 

--- a/catalog/apps/data-tools-library.yaml
+++ b/catalog/apps/data-tools-library.yaml
@@ -22,5 +22,5 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: data-analytics-engineering
+  owner: data-platform
   domain: shared-services

--- a/catalog/apps/data-tools-library.yaml
+++ b/catalog/apps/data-tools-library.yaml
@@ -4,13 +4,10 @@ metadata:
   name: data-tools-library
   title: "Data Tools Library"
   description: >-
-    Python library (hip-data-tools) providing reusable utilities for data
-    engineering: AWS (Athena, S3), Kafka, Cassandra, Google Sheets,
-    MySQL/Oracle, and ETL pipelines. Published to PyPI for use across
-    the hipages data platform.
+    Python library (hip-data-tools) providing reusable utilities for data engineering: AWS (Athena, S3), Kafka, Cassandra, Google Sheets, MySQL/Oracle, and ETL pipelines. Published to PyPI for use across the hipages data platform.
   annotations:
     github.com/project-slug: hipagesgroup/data-tools
-    github.com/team-slug: hipagesgroup/data-platform
+    github.com/team-slug: data-platform
   tags:
     - repo
     - python


### PR DESCRIPTION
FY27 data team split (Joe, 2026-07-05); groups in hipagesgroup/backyard#306.

Moves Backstage ownership for `data-analytics-engineering` entities in this repo to `data-platform`.

- Migrated Backyard badges to backyard.prod host + synced FY27 team-slug annotations
